### PR TITLE
Missing Admin value

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -21,6 +21,7 @@ CREATE TABLE users (
     default_font_size INTEGER DEFAULT 24,
     default_font_color VARCHAR(7) DEFAULT '#FFFFFF',
     -- Monetization and billing fields
+    is_admin BOOLEAN NOT NULL DEFAULT false,
     plan VARCHAR(20) NOT NULL DEFAULT 'free',
     subscription_status VARCHAR(20) NOT NULL DEFAULT 'inactive',
     stripe_customer_id VARCHAR(255) UNIQUE,


### PR DESCRIPTION
There Was a missing admin prima schema value that caused auth to break as the schema/prisma files failed.