### PR TITLE
Add subtitle and wide format toggles with fast path

### DIFF
--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -57,9 +57,6 @@ async def _require_task_owner(
     if not user_id:
         raise HTTPException(status_code=401, detail="User authentication required")
 
-    if not is_font_accessible(font_family, user_id):
-        raise HTTPException(status_code=400, detail="Selected font is not available")
-
     task = await task_service.task_repo.get_task_by_id(db, task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")
@@ -121,6 +118,12 @@ async def create_task(request: Request, db: AsyncSession = Depends(get_db)):
     processing_mode = data.get("processing_mode", config.default_processing_mode)
     if processing_mode not in {"fast", "balanced", "quality"}:
         processing_mode = config.default_processing_mode
+    output_format = data.get("output_format", "vertical")
+    if output_format not in {"vertical", "original"}:
+        output_format = "vertical"
+    add_subtitles = data.get("add_subtitles", True)
+    if not isinstance(add_subtitles, bool):
+        add_subtitles = True
 
     if not raw_source or not raw_source.get("url"):
         raise HTTPException(status_code=400, detail="Source URL is required")
@@ -165,6 +168,8 @@ async def create_task(request: Request, db: AsyncSession = Depends(get_db)):
             font_color,
             caption_template,
             processing_mode,
+            output_format,
+            add_subtitles,
         )
 
         # Save source metadata for resume/retries in environments without sources.url column
@@ -174,7 +179,12 @@ async def create_task(request: Request, db: AsyncSession = Depends(get_db)):
         try:
             await redis_client.set(
                 f"task_source:{task_id}",
-                json.dumps({"url": raw_source["url"], "source_type": source_type}),
+                json.dumps({
+                    "url": raw_source["url"],
+                    "source_type": source_type,
+                    "output_format": output_format,
+                    "add_subtitles": add_subtitles,
+                }),
                 ex=60 * 60 * 24 * 7,
             )
         finally:
@@ -728,20 +738,28 @@ async def resume_task(
 
         source_url = task.get("source_url")
         source_type = task.get("source_type")
+        output_format = "vertical"
+        add_subtitles = True
 
-        if not source_url or not source_type:
-            redis_client = redis.Redis(
-                host=config.redis_host, port=config.redis_port, decode_responses=True
-            )
-            try:
-                source_payload = await redis_client.get(f"task_source:{task_id}")
-            finally:
-                await redis_client.close()
-
+        redis_client = redis.Redis(
+            host=config.redis_host, port=config.redis_port, decode_responses=True
+        )
+        try:
+            source_payload = await redis_client.get(f"task_source:{task_id}")
             if source_payload:
                 parsed = json.loads(source_payload)
-                source_url = parsed.get("url")
-                source_type = parsed.get("source_type")
+                if not source_url:
+                    source_url = parsed.get("url")
+                if not source_type:
+                    source_type = parsed.get("source_type")
+                of = parsed.get("output_format", output_format)
+                if of in ("vertical", "original"):
+                    output_format = of
+                asub = parsed.get("add_subtitles", add_subtitles)
+                if isinstance(asub, bool):
+                    add_subtitles = asub
+        finally:
+            await redis_client.close()
 
         if not source_url or not source_type:
             raise HTTPException(status_code=400, detail="Task source URL is missing")
@@ -776,6 +794,8 @@ async def resume_task(
             task.get("font_color") or "#FFFFFF",
             task.get("caption_template") or "default",
             processing_mode,
+            output_format,
+            add_subtitles,
         )
 
         return {"message": "Task resumed", "job_id": job_id}

--- a/backend/src/services/task_service.py
+++ b/backend/src/services/task_service.py
@@ -11,6 +11,8 @@ import json
 import hashlib
 from time import perf_counter
 
+import redis.asyncio as redis
+
 from ..repositories.task_repository import TaskRepository
 from ..repositories.source_repository import SourceRepository
 from ..repositories.clip_repository import ClipRepository
@@ -126,6 +128,8 @@ class TaskService:
         font_color: str = "#FFFFFF",
         caption_template: str = "default",
         processing_mode: str = "fast",
+        output_format: str = "vertical",
+        add_subtitles: bool = True,
         progress_callback: Optional[Callable] = None,
         should_cancel: Optional[Callable] = None,
     ) -> Dict[str, Any]:
@@ -188,6 +192,8 @@ class TaskService:
                 font_color=font_color,
                 caption_template=caption_template,
                 processing_mode=processing_mode,
+                output_format=output_format,
+                add_subtitles=add_subtitles,
                 cached_transcript=cached_transcript,
                 cached_analysis_json=cached_analysis_json,
                 progress_callback=update_progress,
@@ -405,6 +411,28 @@ class TaskService:
 
         source_url = task.get("source_url")
         source_type = task.get("source_type")
+        output_format = "vertical"
+        add_subtitles = True
+
+        # Preserve original output_format and add_subtitles from task creation (stored in Redis)
+        redis_client = redis.Redis(
+            host=self.config.redis_host,
+            port=self.config.redis_port,
+            decode_responses=True,
+        )
+        try:
+            source_payload = await redis_client.get(f"task_source:{task_id}")
+            if source_payload:
+                parsed = json.loads(source_payload)
+                of = parsed.get("output_format", output_format)
+                if of in ("vertical", "original"):
+                    output_format = of
+                asub = parsed.get("add_subtitles", add_subtitles)
+                if isinstance(asub, bool):
+                    add_subtitles = asub
+        finally:
+            await redis_client.close()
+
         if not source_url or not source_type:
             raise ValueError("Task source URL is missing; cannot regenerate clips")
 
@@ -448,6 +476,8 @@ class TaskService:
             font_size,
             font_color,
             caption_template,
+            output_format,
+            add_subtitles,
         )
 
         await self.clip_repo.delete_clips_by_task(self.db, task_id)

--- a/backend/src/services/video_service.py
+++ b/backend/src/services/video_service.py
@@ -91,12 +91,16 @@ class VideoService:
         font_size: int = 24,
         font_color: str = "#FFFFFF",
         caption_template: str = "default",
+        output_format: str = "vertical",
+        add_subtitles: bool = True,
     ) -> List[Dict[str, Any]]:
         """
-        Create video clips from segments with transitions and subtitles.
+        Create video clips from segments with transitions and optional subtitles.
         Runs in thread pool as video processing is CPU-intensive.
+        output_format: 'vertical' (9:16) or 'original' (keep source size, faster).
+        add_subtitles: False skips subtitles; with original format uses ffmpeg stream copy (no re-encode).
         """
-        logger.info(f"Creating {len(segments)} video clips")
+        logger.info(f"Creating {len(segments)} video clips subtitles={add_subtitles}")
         clips_output_dir = Path(config.temp_dir) / "clips"
         clips_output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -109,6 +113,8 @@ class VideoService:
             font_size,
             font_color,
             caption_template,
+            output_format,
+            add_subtitles,
         )
 
         logger.info(f"Successfully created {len(clips_info)} clips")
@@ -129,6 +135,8 @@ class VideoService:
         font_color: str = "#FFFFFF",
         caption_template: str = "default",
         processing_mode: str = "fast",
+        output_format: str = "vertical",
+        add_subtitles: bool = True,
         cached_transcript: Optional[str] = None,
         cached_analysis_json: Optional[str] = None,
         progress_callback: Optional[Callable[[int, str, str], Awaitable[None]]] = None,
@@ -248,6 +256,8 @@ class VideoService:
                 font_size,
                 font_color,
                 caption_template,
+                output_format,
+                add_subtitles,
             )
 
             if progress_callback:

--- a/backend/src/video_utils.py
+++ b/backend/src/video_utils.py
@@ -1120,17 +1120,44 @@ def create_optimized_clip(
     font_size: int = 24,
     font_color: str = "#FFFFFF",
     caption_template: str = "default",
+    output_format: str = "vertical",
 ) -> bool:
-    """Create optimized 9:16 clip with AssemblyAI subtitles and template support."""
+    """Create clip with optional subtitles. output_format: 'vertical' (9:16) or 'original' (keep source size)."""
     try:
         duration = end_time - start_time
         if duration <= 0:
             logger.error(f"Invalid clip duration: {duration:.1f}s")
             return False
 
+        keep_original = output_format == "original"
         logger.info(
-            f"Creating clip: {start_time:.1f}s - {end_time:.1f}s ({duration:.1f}s) with template '{caption_template}'"
+            f"Creating clip: {start_time:.1f}s - {end_time:.1f}s ({duration:.1f}s) "
+            f"subtitles={add_subtitles} template '{caption_template}' format={'original' if keep_original else 'vertical'}"
         )
+
+        # Fast path: no subtitles + original = ffmpeg stream copy (no re-encoding)
+        if not add_subtitles and keep_original:
+            import subprocess
+            result = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-ss", str(start_time),
+                    "-i", str(video_path),
+                    "-t", str(duration),
+                    "-c", "copy",
+                    "-movflags", "+faststart",
+                    str(output_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                logger.error(f"ffmpeg stream copy failed: {result.stderr}")
+                return False
+            logger.info(f"Successfully created clip (stream copy): {output_path}")
+            return True
 
         # Load and process video
         video = VideoFileClip(str(video_path))
@@ -1145,18 +1172,24 @@ def create_optimized_clip(
         end_time = min(end_time, video.duration)
         clip = video.subclipped(start_time, end_time)
 
-        # Get optimal crop
-        x_offset, y_offset, new_width, new_height = detect_optimal_crop_region(
-            video, start_time, end_time, target_ratio=9 / 16
-        )
-
-        cropped_clip = clip.cropped(
-            x1=x_offset, y1=y_offset, x2=x_offset + new_width, y2=y_offset + new_height
-        )
-
-        # Normalize all generated clips to a platform-ready 1080x1920 canvas.
-        target_width, target_height = 1080, 1920
-        processed_clip = cropped_clip.resized((target_width, target_height))
+        if keep_original:
+            # No face detection, no crop, no resize - use trimmed clip as-is
+            processed_clip = clip
+            target_width = round_to_even(processed_clip.w)
+            target_height = round_to_even(processed_clip.h)
+            if (target_width, target_height) != (processed_clip.w, processed_clip.h):
+                processed_clip = processed_clip.resized((target_width, target_height))
+            cropped_clip = None
+        else:
+            # Vertical 9:16: face-centered crop + resize to 1080x1920
+            x_offset, y_offset, new_width, new_height = detect_optimal_crop_region(
+                video, start_time, end_time, target_ratio=9 / 16
+            )
+            cropped_clip = clip.cropped(
+                x1=x_offset, y1=y_offset, x2=x_offset + new_width, y2=y_offset + new_height
+            )
+            target_width, target_height = 1080, 1920
+            processed_clip = cropped_clip.resized((target_width, target_height))
 
         # Add AssemblyAI subtitles with template support
         final_clips = [processed_clip]
@@ -1196,7 +1229,8 @@ def create_optimized_clip(
         # Cleanup
         final_clip.close()
         clip.close()
-        cropped_clip.close()
+        if cropped_clip is not None:
+            cropped_clip.close()
         if processed_clip is not final_clip:
             processed_clip.close()
         video.close()
@@ -1217,10 +1251,12 @@ def create_clips_from_segments(
     font_size: int = 24,
     font_color: str = "#FFFFFF",
     caption_template: str = "default",
+    output_format: str = "vertical",
+    add_subtitles: bool = True,
 ) -> List[Dict[str, Any]]:
     """Create optimized video clips from segments with template support."""
     logger.info(
-        f"Creating {len(segments)} clips with caption template '{caption_template}'"
+        f"Creating {len(segments)} clips subtitles={add_subtitles} template '{caption_template}'"
     )
 
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1255,11 +1291,12 @@ def create_clips_from_segments(
                 start_seconds,
                 end_seconds,
                 clip_path,
-                True,
+                add_subtitles,
                 font_family,
                 font_size,
                 font_color,
                 caption_template,
+                output_format,
             )
 
             if success:
@@ -1376,10 +1413,12 @@ def create_clips_with_transitions(
     font_size: int = 24,
     font_color: str = "#FFFFFF",
     caption_template: str = "default",
+    output_format: str = "vertical",
+    add_subtitles: bool = True,
 ) -> List[Dict[str, Any]]:
     """Create video clips with transition effects between them."""
     logger.info(
-        f"Creating {len(segments)} clips with transitions and caption template '{caption_template}'"
+        f"Creating {len(segments)} clips subtitles={add_subtitles} transitions template '{caption_template}'"
     )
 
     # First create individual clips
@@ -1391,6 +1430,8 @@ def create_clips_with_transitions(
         font_size,
         font_color,
         caption_template,
+        output_format,
+        add_subtitles,
     )
 
     if len(clips_info) < 2:

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -24,6 +24,8 @@ async def process_video_task(
     font_color: str = "#FFFFFF",
     caption_template: str = "default",
     processing_mode: str = "fast",
+    output_format: str = "vertical",
+    add_subtitles: bool = True,
 ) -> Dict[str, Any]:
     """
     Background worker task to process a video.
@@ -76,6 +78,8 @@ async def process_video_task(
                 font_color=font_color,
                 caption_template=caption_template,
                 processing_mode=processing_mode,
+                output_format=output_format,
+                add_subtitles=add_subtitles,
                 progress_callback=update_progress,
                 should_cancel=should_cancel,
             )

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -78,6 +78,8 @@ export default function Home() {
   const [availableTemplates, setAvailableTemplates] = useState<Array<{ id: string, name: string, description: string, animation: string, font_family?: string, font_size?: number, font_color?: string }>>([]);
   const [includeBroll, setIncludeBroll] = useState(false);
   const [brollAvailable, setBrollAvailable] = useState(false);
+  const [outputFormat, setOutputFormat] = useState<"vertical" | "original">("vertical");
+  const [addSubtitles, setAddSubtitles] = useState(true);
 
   // Latest task state
   const [latestTask, setLatestTask] = useState<LatestTask | null>(null);
@@ -407,7 +409,9 @@ export default function Home() {
           },
           caption_template: captionTemplate,
           include_broll: includeBroll,
-          processing_mode: "fast"
+          processing_mode: "fast",
+          output_format: outputFormat,
+          add_subtitles: addSubtitles
         }),
       });
 
@@ -739,6 +743,38 @@ export default function Home() {
                       />
                     </div>
                   )}
+
+                  {/* Output format */}
+                  <div className="flex items-center justify-between p-3 border rounded-lg bg-stone-50">
+                    <div className="flex items-center gap-3">
+                      <Monitor className="w-4 h-4 text-blue-500" />
+                      <div>
+                        <h3 className="text-sm font-medium text-stone-900">Wide format</h3>
+                        <p className="text-xs text-stone-500">Keep original aspect ratio instead of 9:16 vertical</p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={outputFormat === "original"}
+                      onCheckedChange={(checked) => setOutputFormat(checked ? "original" : "vertical")}
+                      disabled={isLoading}
+                    />
+                  </div>
+
+                  {/* Add subtitles */}
+                  <div className="flex items-center justify-between p-3 border rounded-lg bg-stone-50">
+                    <div className="flex items-center gap-3">
+                      <Type className="w-4 h-4 text-emerald-500" />
+                      <div>
+                        <h3 className="text-sm font-medium text-stone-900">Add subtitles</h3>
+                        <p className="text-xs text-stone-500">Burn captions onto clips (disable for faster processing)</p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={addSubtitles}
+                      onCheckedChange={setAddSubtitles}
+                      disabled={isLoading}
+                    />
+                  </div>
                 </CardContent>
               </Card>
 


### PR DESCRIPTION
**Summary**

- Adds two processing options to the video pipeline:
- Add subtitles – Toggle burning captions onto clips (off = faster processing).
- Wide format – Toggle between 9:16 vertical and original aspect ratio.
- When both are off (no subtitles + original format), clips use ffmpeg stream copy instead of re-encoding, which speeds up processing.

**Changes
Backend**
- output_format and add_subtitles added to the create-task API, worker, and pipeline.
- Fast path in create_optimized_clip: when add_subtitles=False and output_format="original", use ffmpeg -c copy instead of MoviePy re-encode.
- Settings stored in Redis (task_source:{task_id}) for resume and regeneration.
- resume_task reads and validates output_format and add_subtitles from Redis.
- regenerate_all_clips_for_task reads these from Redis and passes them to create_video_clips so regenerated clips match the original settings.
- Validation for Redis values: output_format must be "vertical" or "original"; add_subtitles must be a boolean.

**Frontend**
- Two new toggles in the Style & Captions section:
- Wide format – Keep original aspect ratio instead of 9:16 vertical.
- Add subtitles – Burn captions onto clips (disable for faster processing).
**Bug fixes**
- Removed invalid font_family reference from _require_task_owner (was causing NameError on clip editing endpoints).
- Added validation for output_format and add_subtitles when read from Redis in resume_task and regenerate_all_clips_for_task.