### PR TITLE
fix(backend): authorize task title updates

### DIFF
--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -358,10 +358,7 @@ async def update_task(
 
         task_service = TaskService(db)
 
-        # Get task to verify it exists
-        task = await task_service.task_repo.get_task_by_id(db, task_id)
-        if not task:
-            raise HTTPException(status_code=404, detail="Task not found")
+        task = await _require_task_owner(request, task_service, db, task_id)
 
         # Update source title
         await task_service.source_repo.update_source_title(db, task["source_id"], title)


### PR DESCRIPTION
## Summary
- require task ownership before updating a task title
- reuse the shared task owner guard for consistent auth behavior

## Verification
- python3 -m py_compile backend/src/api/routes/tasks.py