### PR TITLE
fix(frontend): proxy task API through Next auth

### DIFF
--- a/frontend/src/app/api/tasks/[...path]/route.ts
+++ b/frontend/src/app/api/tasks/[...path]/route.ts
@@ -1,0 +1,91 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { buildBackendAuthHeaders } from "@/lib/backend-auth";
+
+const FORWARDED_RESPONSE_HEADERS = [
+  "cache-control",
+  "content-disposition",
+  "content-type",
+  "x-trace-id",
+] as const;
+
+async function proxyTaskRequest(
+  request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { path } = await params;
+  const apiUrl =
+    process.env.BACKEND_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:8000";
+  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+  const incomingUrl = new URL(request.url);
+  const targetUrl = `${normalizedApiUrl}/tasks/${path.join("/")}${incomingUrl.search}`;
+  const body =
+    request.method === "GET" || request.method === "HEAD"
+      ? undefined
+      : await request.text();
+
+  const upstream = await fetch(targetUrl, {
+    method: request.method,
+    headers: {
+      ...buildBackendAuthHeaders(session.user.id),
+      ...(body && request.headers.get("content-type")
+        ? { "Content-Type": request.headers.get("content-type") as string }
+        : {}),
+      ...(request.headers.get("accept")
+        ? { Accept: request.headers.get("accept") as string }
+        : {}),
+    },
+    body,
+    cache: "no-store",
+  });
+
+  const responseHeaders = new Headers();
+  for (const headerName of FORWARDED_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(headerName);
+    if (value) {
+      responseHeaders.set(headerName, value);
+    }
+  }
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: responseHeaders,
+  });
+}
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxyTaskRequest(request, context);
+}
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxyTaskRequest(request, context);
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxyTaskRequest(request, context);
+}
+
+export async function DELETE(
+  request: Request,
+  context: { params: Promise<{ path: string[] }> }
+) {
+  return proxyTaskRequest(request, context);
+}

--- a/frontend/src/app/api/tasks/route.ts
+++ b/frontend/src/app/api/tasks/route.ts
@@ -1,0 +1,35 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { buildBackendAuthHeaders } from "@/lib/backend-auth";
+
+export async function GET() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const apiUrl =
+    process.env.BACKEND_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:8000";
+  const upstream = await fetch(`${apiUrl}/tasks/`, {
+    method: "GET",
+    headers: buildBackendAuthHeaders(session.user.id),
+    cache: "no-store",
+  });
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") || "application/json",
+      ...(upstream.headers.get("cache-control")
+        ? { "Cache-Control": upstream.headers.get("cache-control") as string }
+        : {}),
+      ...(upstream.headers.get("x-trace-id")
+        ? { "x-trace-id": upstream.headers.get("x-trace-id") as string }
+        : {}),
+    },
+  });
+}

--- a/frontend/src/app/list/page.tsx
+++ b/frontend/src/app/list/page.tsx
@@ -28,18 +28,14 @@ export default function ListPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-
   useEffect(() => {
     const fetchTasks = async () => {
       if (!session?.user?.id) return;
 
       try {
         setIsLoading(true);
-        const response = await fetch(`${apiUrl}/tasks/`, {
-          headers: {
-            'user_id': session.user.id,
-          },
+        const response = await fetch("/api/tasks/", {
+          cache: "no-store",
         });
 
         if (!response.ok) {
@@ -57,7 +53,7 @@ export default function ListPage() {
     };
 
     fetchTasks();
-  }, [session?.user?.id, apiUrl]);
+  }, [session?.user?.id]);
 
   const getStatusBadge = (status: string) => {
     switch (status) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -123,6 +123,7 @@ export default function Home() {
   const [isLoadingLatest, setIsLoadingLatest] = useState(false);
   const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null);
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+  const taskApiUrl = "/api/tasks";
   const youtubeThumbnailUrl = sourceType === "youtube" ? getYouTubeThumbnailUrl(url) : null;
 
   const refreshFonts = useCallback(async () => {
@@ -229,10 +230,8 @@ export default function Home() {
 
       try {
         setIsLoadingLatest(true);
-        const response = await fetch(`${apiUrl}/tasks/`, {
-          headers: {
-            'user_id': session.user.id,
-          },
+        const response = await fetch(`${taskApiUrl}/`, {
+          cache: "no-store",
         });
 
         if (response.ok) {
@@ -249,7 +248,7 @@ export default function Home() {
     };
 
     fetchLatestTask();
-  }, [session?.user?.id, apiUrl]);
+  }, [session?.user?.id, taskApiUrl]);
 
   useEffect(() => {
     const fetchBillingSummary = async () => {

--- a/frontend/src/app/tasks/[id]/edit/page.tsx
+++ b/frontend/src/app/tasks/[id]/edit/page.tsx
@@ -91,6 +91,7 @@ export default function TaskEditPage() {
   const params = useParams();
   const { data: session } = useSession();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const taskApiUrl = "/api/tasks";
 
   const [task, setTask] = useState<TaskDetails | null>(null);
   const [clips, setClips] = useState<Clip[]>([]);
@@ -173,11 +174,8 @@ export default function TaskEditPage() {
     if (!params.id) return;
     setError(null);
 
-    const headers: HeadersInit = {};
-    if (session?.user?.id) headers.user_id = session.user.id;
-
     try {
-      const taskResponse = await fetch(`${apiUrl}/tasks/${params.id}`, { headers });
+      const taskResponse = await fetch(`${taskApiUrl}/${params.id}`, { cache: "no-store" });
       if (!taskResponse.ok) {
         throw new Error(await buildSupportError(taskResponse, `Failed to fetch task: ${taskResponse.status}`));
       }
@@ -190,7 +188,7 @@ export default function TaskEditPage() {
         return;
       }
 
-      const clipsResponse = await fetch(`${apiUrl}/tasks/${params.id}/clips`, { headers });
+      const clipsResponse = await fetch(`${taskApiUrl}/${params.id}/clips`, { cache: "no-store" });
       if (!clipsResponse.ok) {
         throw new Error(await buildSupportError(clipsResponse, `Failed to fetch clips: ${clipsResponse.status}`));
       }
@@ -208,7 +206,7 @@ export default function TaskEditPage() {
     } catch (fetchError) {
       setError(fetchError instanceof Error ? fetchError.message : "Failed to load editor");
     }
-  }, [apiUrl, buildSupportError, params.id, session?.user?.id]);
+  }, [buildSupportError, params.id, taskApiUrl]);
 
   useEffect(() => {
     const run = async () => {
@@ -259,11 +257,10 @@ export default function TaskEditPage() {
     const endOffset = Number((selectedClip.duration - trimRange[1]).toFixed(2));
 
     await withSaving(async () => {
-      const response = await fetch(`${apiUrl}/tasks/${task.id}/clips/${selectedClip.id}`, {
+      const response = await fetch(`${taskApiUrl}/${task.id}/clips/${selectedClip.id}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({ start_offset: startOffset, end_offset: endOffset }),
       });
@@ -275,11 +272,10 @@ export default function TaskEditPage() {
     if (!selectedClip || !session?.user?.id || !task?.id) return;
     const value = splitAt ?? splitTime;
     await withSaving(async () => {
-      const response = await fetch(`${apiUrl}/tasks/${task.id}/clips/${selectedClip.id}/split`, {
+      const response = await fetch(`${taskApiUrl}/${task.id}/clips/${selectedClip.id}/split`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({ split_time: Number(value.toFixed(2)) }),
       });
@@ -291,11 +287,10 @@ export default function TaskEditPage() {
     if (!selectedClip || !session?.user?.id || !task?.id) return;
 
     await withSaving(async () => {
-      const response = await fetch(`${apiUrl}/tasks/${task.id}/clips/${selectedClip.id}/captions`, {
+      const response = await fetch(`${taskApiUrl}/${task.id}/clips/${selectedClip.id}/captions`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({
           caption_text: captionText,
@@ -310,11 +305,10 @@ export default function TaskEditPage() {
   const handleMerge = async () => {
     if (!session?.user?.id || !task?.id || mergeSelection.length < 2) return;
     await withSaving(async () => {
-      const response = await fetch(`${apiUrl}/tasks/${task.id}/clips/merge`, {
+      const response = await fetch(`${taskApiUrl}/${task.id}/clips/merge`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({ clip_ids: mergeSelection }),
       });

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -132,6 +132,7 @@ export default function TaskPage() {
   const hasTriggeredAutoRefresh = useRef(false);
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const taskApiUrl = "/api/tasks";
 
   const buildSupportError = useCallback(async (response: Response, fallbackMessage: string) => {
     const parsed = await parseApiError(response, fallbackMessage);
@@ -151,15 +152,8 @@ export default function TaskPage() {
       if (!params.id) return false;
 
       try {
-        // Fetch task details (including status)
-        // Don't wait for session - fetch immediately with user_id if available
-        const headers: HeadersInit = {};
-        if (session?.user?.id) {
-          headers["user_id"] = session.user.id;
-        }
-
-        const taskResponse = await fetch(`${apiUrl}/tasks/${params.id}`, {
-          headers,
+        const taskResponse = await fetch(`${taskApiUrl}/${params.id}`, {
+          cache: "no-store",
         });
 
         // Handle 404 with retry logic (task might not be persisted yet)
@@ -185,13 +179,8 @@ export default function TaskPage() {
 
         // Only fetch clips if task is completed
         if (taskData.status === "completed") {
-          const clipsHeaders: HeadersInit = {};
-          if (session?.user?.id) {
-            clipsHeaders["user_id"] = session.user.id;
-          }
-
-          const clipsResponse = await fetch(`${apiUrl}/tasks/${params.id}/clips`, {
-            headers: clipsHeaders,
+          const clipsResponse = await fetch(`${taskApiUrl}/${params.id}/clips`, {
+            cache: "no-store",
           });
 
           if (!clipsResponse.ok) {
@@ -209,7 +198,7 @@ export default function TaskPage() {
         return false;
       }
     },
-    [apiUrl, buildSupportError, params.id, session?.user?.id],
+    [buildSupportError, params.id, taskApiUrl],
   );
 
   // Initial fetch - runs immediately, doesn't wait for session
@@ -266,8 +255,7 @@ export default function TaskPage() {
     // Only connect to SSE if task is queued or processing
     if (taskStatus !== "queued" && taskStatus !== "processing") return;
 
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
-    const eventSource = new EventSource(`${apiUrl}/tasks/${params.id}/progress`);
+    const eventSource = new EventSource(`${taskApiUrl}/${params.id}/progress`);
 
     console.log("📡 Connected to SSE for real-time progress");
 
@@ -322,7 +310,7 @@ export default function TaskPage() {
       console.log("🔌 Disconnecting SSE");
       eventSource.close();
     };
-  }, [params.id, task?.status, fetchTaskStatus]); // Re-run when task status changes
+  }, [params.id, task?.status, fetchTaskStatus, taskApiUrl, triggerAutoRefresh]); // Re-run when task status changes
 
   const formatDuration = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
@@ -366,11 +354,10 @@ export default function TaskPage() {
     if (!editedTitle.trim() || !session?.user?.id || !params.id) return;
 
     try {
-      const response = await fetch(`${apiUrl}/tasks/${params.id}`, {
+      const response = await fetch(`${taskApiUrl}/${params.id}`, {
         method: "PATCH",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({ title: editedTitle }),
       });
@@ -392,11 +379,8 @@ export default function TaskPage() {
 
     setIsDeleting(true);
     try {
-      const response = await fetch(`${apiUrl}/tasks/${params.id}`, {
+      const response = await fetch(`${taskApiUrl}/${params.id}`, {
         method: "DELETE",
-        headers: {
-          user_id: session.user.id,
-        },
       });
 
       if (response.ok) {
@@ -417,11 +401,8 @@ export default function TaskPage() {
     if (!session?.user?.id || !params.id) return;
 
     try {
-      const response = await fetch(`${apiUrl}/tasks/${params.id}/clips/${clipId}`, {
+      const response = await fetch(`${taskApiUrl}/${params.id}/clips/${clipId}`, {
         method: "DELETE",
-        headers: {
-          user_id: session.user.id,
-        },
       });
 
       if (response.ok) {
@@ -447,11 +428,10 @@ export default function TaskPage() {
 
   const handleTrimClip = async (clipId: string) => {
     if (!session?.user?.id || !params.id) return;
-    const response = await fetch(`${apiUrl}/tasks/${params.id}/clips/${clipId}`, {
+    const response = await fetch(`${taskApiUrl}/${params.id}/clips/${clipId}`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        user_id: session.user.id,
       },
       body: JSON.stringify({
         start_offset: Number(startOffset || "0"),
@@ -467,11 +447,10 @@ export default function TaskPage() {
 
   const handleSplitClip = async (clipId: string) => {
     if (!session?.user?.id || !params.id) return;
-    const response = await fetch(`${apiUrl}/tasks/${params.id}/clips/${clipId}/split`, {
+    const response = await fetch(`${taskApiUrl}/${params.id}/clips/${clipId}/split`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        user_id: session.user.id,
       },
       body: JSON.stringify({ split_time: Number(splitTime || "5") }),
     });
@@ -484,11 +463,10 @@ export default function TaskPage() {
 
   const handleMergeClips = async () => {
     if (!session?.user?.id || !params.id || selectedClipIds.length < 2) return;
-    const response = await fetch(`${apiUrl}/tasks/${params.id}/clips/merge`, {
+    const response = await fetch(`${taskApiUrl}/${params.id}/clips/merge`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        user_id: session.user.id,
       },
       body: JSON.stringify({ clip_ids: selectedClipIds }),
     });
@@ -502,11 +480,10 @@ export default function TaskPage() {
 
   const handleUpdateCaptions = async (clipId: string) => {
     if (!session?.user?.id || !params.id) return;
-    const response = await fetch(`${apiUrl}/tasks/${params.id}/clips/${clipId}/captions`, {
+    const response = await fetch(`${taskApiUrl}/${params.id}/clips/${clipId}/captions`, {
       method: "PATCH",
       headers: {
         "Content-Type": "application/json",
-        user_id: session.user.id,
       },
       body: JSON.stringify({
         caption_text: captionText,
@@ -532,11 +509,10 @@ export default function TaskPage() {
 
     setIsApplyingSettings(true);
     try {
-      const response = await fetch(`${apiUrl}/tasks/${params.id}/settings`, {
+      const response = await fetch(`${taskApiUrl}/${params.id}/settings`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          user_id: session.user.id,
         },
         body: JSON.stringify({
           font_family: projectFontFamily,
@@ -560,10 +536,8 @@ export default function TaskPage() {
   const handleExportClip = async (clipId: string, fallbackFilename: string) => {
     if (!session?.user?.id || !task?.id) return;
 
-    const response = await fetch(`${apiUrl}/tasks/${task.id}/clips/${clipId}/export?preset=${exportPreset}`, {
-      headers: {
-        user_id: session.user.id,
-      },
+    const response = await fetch(`${taskApiUrl}/${task.id}/clips/${clipId}/export?preset=${exportPreset}`, {
+      cache: "no-store",
     });
 
     if (!response.ok) {
@@ -703,7 +677,7 @@ export default function TaskPage() {
                   <div className="relative group">
                     <Badge className="bg-blue-100 text-blue-800 cursor-default">Processing</Badge>
                     <div className="absolute top-full mt-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md opacity-0 scale-95 transition-all group-hover:opacity-100 group-hover:scale-100 pointer-events-none">
-                      🔍&nbsp;&nbsp;We're currently processing your video. Check back in a couple minutes.
+                      🔍&nbsp;&nbsp;We&apos;re currently processing your video. Check back in a couple minutes.
                     </div>
                   </div>
                 ) : task.status === "queued" ? (
@@ -726,11 +700,8 @@ export default function TaskPage() {
                     size="sm"
                     variant="outline"
                     onClick={async () => {
-                      await fetch(`${apiUrl}/tasks/${task.id}/cancel`, {
+                      await fetch(`${taskApiUrl}/${task.id}/cancel`, {
                         method: "POST",
-                        headers: {
-                          user_id: session?.user?.id || "",
-                        },
                       });
                       await fetchTaskStatus();
                     }}
@@ -743,11 +714,8 @@ export default function TaskPage() {
                     size="sm"
                     variant="outline"
                     onClick={async () => {
-                      await fetch(`${apiUrl}/tasks/${task.id}/resume`, {
+                      await fetch(`${taskApiUrl}/${task.id}/resume`, {
                         method: "POST",
-                        headers: {
-                          user_id: session?.user?.id || "",
-                        },
                       });
                       await fetchTaskStatus();
                     }}


### PR DESCRIPTION
## Summary
- add authenticated Next route proxies for task list, detail, and mutation requests
- route task list, detail, editor, export, cancel/resume, and progress SSE through same-origin APIs
- stop sending unsigned user_id headers from the browser in monetized mode

## Verification
- cd frontend && npx eslint src/app/api/tasks/route.ts 'src/app/api/tasks/[...path]/route.ts' src/app/list/page.tsx src/app/page.tsx 'src/app/tasks/[id]/page.tsx' 'src/app/tasks/[id]/edit/page.tsx'