### PR TITLE
feat(frontend): add DataFast tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,19 @@ DISABLE_SIGN_UP=false
 # Set to true to disable all routes except the landing page.
 NEXT_PUBLIC_LANDING_ONLY_MODE=false
 
+# ==============================================
+# Analytics (optional)
+# ==============================================
+
+# DataFast public website ID (example: dfid_xxxxxx)
+NEXT_PUBLIC_DATAFAST_WEBSITE_ID=
+
+# DataFast tracked domain without protocol (example: supoclip.com)
+NEXT_PUBLIC_DATAFAST_DOMAIN=
+
+# Set to true only when you want to test DataFast on localhost
+NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST=false
+
 # Resend API key for waitlist confirmation emails (optional)
 RESEND_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -88,9 +88,14 @@ GOOGLE_API_KEY=your_google_api_key
 # Optional: Auth secret (change in production)
 BETTER_AUTH_SECRET=change_this_in_production
 
-# Optional: Resend for waitlist + subscription lifecycle emails
-RESEND_API_KEY=your_resend_api_key
-RESEND_FROM_EMAIL="SupoClip <onboarding@your-domain.com>"
+# Optional: DataFast analytics
+# Track your deployed domain in DataFast
+# NEXT_PUBLIC_DATAFAST_WEBSITE_ID=dfid_xxxxx
+# NEXT_PUBLIC_DATAFAST_DOMAIN=your-domain.com
+# NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST=false
+
+# Optional: Resend for waitlist confirmation emails
+# RESEND_API_KEY=your_resend_api_key
 ```
 
 ### 2. Start the Services
@@ -118,6 +123,11 @@ Wait until you see health checks passing for all services.
 ### 4. Access the App
 
 Open http://localhost:3000 in your browser, create an account, and start clipping!
+
+If you enable DataFast, also verify that:
+- `/js/script.js` loads from your own app domain
+- `/api/events` requests are proxied through your app domain
+- custom goals appear after successful sign-up, sign-in, task creation, billing, feedback, or waitlist actions
 
 ### Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ If you are new to the project, start here:
   - Production-minded setup notes
 - [Configuration](./configuration.md)
   - Required API keys
+  - DataFast analytics settings
   - Processing modes
   - Auth and monetization settings
   - YouTube auth rotation settings
@@ -89,4 +90,3 @@ This new docs tree replaces the need to hunt across several markdown files, but 
 - [`CLAUDE.md`](../CLAUDE.md)
 - [`REFACTORING_COMPLETE.md`](../REFACTORING_COMPLETE.md)
 - [`backend/REFACTORING_GUIDE.md`](../backend/REFACTORING_GUIDE.md)
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,31 @@ The backend can infer a default LLM from whichever API key is present, but setti
 | `TEMP_DIR` | `/app/uploads` in Docker | Temporary backend working directory for uploads and processing |
 | `CORS_ORIGINS` | `http://localhost:3000,http://sp.localhost:3000` | Allowed browser origins for backend requests |
 
+## Analytics Settings
+
+SupoClip can send pageviews and custom product events to DataFast from the `frontend` app.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `NEXT_PUBLIC_DATAFAST_WEBSITE_ID` | unset | Public DataFast website ID used by the tracking script |
+| `NEXT_PUBLIC_DATAFAST_DOMAIN` | unset | Root domain tracked by DataFast, for example `supoclip.com` |
+| `NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST` | `false` | Enables local tracking on `localhost` when explicitly set to `true` |
+
+### DataFast behavior
+
+- Tracking stays disabled unless both `NEXT_PUBLIC_DATAFAST_WEBSITE_ID` and `NEXT_PUBLIC_DATAFAST_DOMAIN` are set.
+- The frontend proxies DataFast through `/js/script.js` and `/api/events` using Next.js rewrites to reduce ad blocker loss.
+- Localhost is excluded by default to avoid polluting production analytics.
+- The current custom goals are:
+  - `signup_completed`
+  - `signin_completed`
+  - `task_created`
+  - `billing_checkout_started`
+  - `billing_portal_opened`
+  - `preferences_saved`
+  - `feedback_submitted`
+  - `waitlist_submitted`
+
 ## Processing Settings
 
 These settings affect clip generation speed, throughput, and defaults.
@@ -152,6 +177,9 @@ These are especially relevant in Docker and deployments:
 |---|---|
 | `NEXT_PUBLIC_API_URL` | Browser-facing backend base URL |
 | `NEXT_PUBLIC_APP_URL` | Canonical frontend URL |
+| `NEXT_PUBLIC_DATAFAST_WEBSITE_ID` | Public DataFast website ID |
+| `NEXT_PUBLIC_DATAFAST_DOMAIN` | Domain passed to the DataFast script |
+| `NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST` | Enables local DataFast testing |
 | `BACKEND_INTERNAL_URL` | Internal backend URL used by frontend server routes |
 | `BETTER_AUTH_URL` | Auth origin for Better Auth |
 | `NEXT_PUBLIC_SELF_HOST` | Exposes self-host mode to the frontend |
@@ -186,6 +214,14 @@ BETTER_AUTH_SECRET=replace_me
 SELF_HOST=true
 ```
 
+To enable DataFast on a deployed frontend, add:
+
+```env
+NEXT_PUBLIC_DATAFAST_WEBSITE_ID=dfid_xxxxx
+NEXT_PUBLIC_DATAFAST_DOMAIN=your-domain.com
+NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST=false
+```
+
 For hosted monetized use, add at minimum:
 
 ```env
@@ -203,4 +239,3 @@ RESEND_FROM_EMAIL="SupoClip <onboarding@your-domain.com>"
 - [Setup](./setup.md)
 - [Troubleshooting](./troubleshooting.md)
 - [Architecture](./architecture.md)
-

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -21,6 +21,7 @@ This guide covers the recommended Docker setup, local development mode, and the 
 ### Optional credentials
 
 - `PEXELS_API_KEY` for AI B-roll sourcing
+- `NEXT_PUBLIC_DATAFAST_WEBSITE_ID` and `NEXT_PUBLIC_DATAFAST_DOMAIN` for DataFast analytics
 - `RESEND_API_KEY` and `RESEND_FROM_EMAIL` for hosted billing emails
 - Stripe keys if you are running with monetization enabled
 - Discord webhook URLs for feedback forwarding
@@ -50,6 +51,11 @@ LLM=google-gla:gemini-3-flash-preview
 GOOGLE_API_KEY=your_google_key
 BETTER_AUTH_SECRET=replace_this_for_real_use
 BACKEND_AUTH_SECRET=replace_this_if_using_hosted_mode
+
+# Optional: DataFast analytics
+NEXT_PUBLIC_DATAFAST_WEBSITE_ID=dfid_xxxxx
+NEXT_PUBLIC_DATAFAST_DOMAIN=your-domain.com
+NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST=false
 ```
 
 ### 3. Start the stack
@@ -115,6 +121,8 @@ After the stack is up:
 4. Open the task page and confirm progress updates appear.
 5. Wait for clip generation to finish.
 6. Open the clips list and verify playback and download work.
+7. If DataFast is enabled, open browser devtools and confirm `/js/script.js` and `/api/events` load from your own domain.
+8. Trigger one successful action such as sign-up, sign-in, task creation, feedback submission, or waitlist submission and verify the goal arrives in DataFast.
 
 ## Local Development Without Docker
 
@@ -187,10 +195,12 @@ For anything beyond local experimentation:
 - Change `BETTER_AUTH_SECRET`
 - Set a strong `BACKEND_AUTH_SECRET`
 - Put the app behind HTTPS
+- Set `NEXT_PUBLIC_APP_URL` to your deployed frontend origin
 - Use persistent storage and backups for PostgreSQL
 - Keep API keys outside version control
 - Decide whether you want self-host mode or monetized hosted mode before launch
 - Verify all callback URLs and origins match your deployed domain
+- If using DataFast, set `NEXT_PUBLIC_DATAFAST_DOMAIN` to the deployed root domain you want tracked
 
 ## Useful Commands
 
@@ -228,4 +238,3 @@ Warning: `docker-compose down -v` deletes database and Redis data.
 - Review [Configuration](./configuration.md) before changing defaults
 - Review [App Guide](./app-guide.md) to understand the UI and workflows
 - Review [Troubleshooting](./troubleshooting.md) if tasks do not process correctly
-

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -10,6 +10,18 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  async rewrites() {
+    return [
+      {
+        source: "/js/script.js",
+        destination: "https://datafa.st/js/script.js",
+      },
+      {
+        source: "/api/events",
+        destination: "https://datafa.st/api/events",
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono, Syne } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
+import { DataFastIdentity } from "@/components/datafast-identity";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { FeedbackButton } from "@/components/feedback-button";
@@ -31,6 +33,11 @@ const syne = Syne({
   weight: ["400", "500", "600", "700", "800"],
 });
 
+const dataFastWebsiteId = process.env.NEXT_PUBLIC_DATAFAST_WEBSITE_ID;
+const dataFastDomain = process.env.NEXT_PUBLIC_DATAFAST_DOMAIN;
+const shouldTrackLocalhost = process.env.NEXT_PUBLIC_DATAFAST_ALLOW_LOCALHOST === "true";
+const isDataFastEnabled = Boolean(dataFastWebsiteId && dataFastDomain);
+
 export const metadata: Metadata = {
   title: "SupoClip",
   description: "Turn long videos into viral-ready shorts.",
@@ -58,9 +65,31 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {isDataFastEnabled ? (
+          <>
+            <Script id="datafast-queue" strategy="beforeInteractive">
+              {`window.datafast = window.datafast || function() {
+  window.datafast.q = window.datafast.q || [];
+  window.datafast.q.push(arguments);
+};`}
+            </Script>
+            <Script
+              id="datafast-script"
+              strategy="afterInteractive"
+              src="/js/script.js"
+              data-website-id={dataFastWebsiteId}
+              data-domain={dataFastDomain}
+              data-allow-localhost={shouldTrackLocalhost ? "true" : undefined}
+              data-disable-console="true"
+            />
+          </>
+        ) : null}
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable} ${syne.variable} antialiased`}>
         <TooltipProvider>
           {children}
+          <DataFastIdentity />
           <FeedbackButton />
           <Toaster />
         </TooltipProvider>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { signOut, useSession } from "@/lib/auth-client";
+import { track } from "@/lib/datafast";
 import { formatSupportMessage, parseApiError } from "@/lib/api-error";
 import Link from "next/link";
 import Image from "next/image";
@@ -462,6 +463,14 @@ export default function Home() {
 
       const startResult = await startResponse.json();
       const taskIdFromStart = startResult.task_id;
+      track("task_created", {
+        source_type: sourceType,
+        caption_template: captionTemplate,
+        include_broll: includeBroll,
+        output_format: outputFormat,
+        add_subtitles: addSubtitles,
+        processing_mode: "fast",
+      });
       // Redirect immediately to the task page
       window.location.href = `/tasks/${taskIdFromStart}`;
 

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Slider } from "@/components/ui/slider";
 import { signOut, useSession } from "@/lib/auth-client";
+import { track } from "@/lib/datafast";
 import Link from "next/link";
 import { Type, Palette, CheckCircle, AlertCircle, Settings, ArrowLeft } from "lucide-react";
 
@@ -148,6 +149,9 @@ export default function SettingsPage() {
         throw new Error(data.error || "Unable to open billing");
       }
 
+      track(billingSummary.plan === "pro" ? "billing_portal_opened" : "billing_checkout_started", {
+        plan: billingSummary.plan,
+      });
       window.location.href = data.url;
     } catch (billingError) {
       setError(billingError instanceof Error ? billingError.message : "Billing action failed");
@@ -179,6 +183,7 @@ export default function SettingsPage() {
         throw new Error(errorData.error || 'Failed to save preferences');
       }
 
+      track("preferences_saved");
       setSuccess(true);
       setTimeout(() => setSuccess(false), 3000);
     } catch (error) {

--- a/frontend/src/components/auth/sign-in.tsx
+++ b/frontend/src/components/auth/sign-in.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { signIn } from "../../lib/auth-client";
+import { track } from "@/lib/datafast";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
@@ -30,6 +31,9 @@ export function SignIn() {
       return;
     }
 
+    track("signin_completed", {
+      auth_method: "email",
+    });
     setMessage("Signed in successfully!");
     setLoading(false);
 

--- a/frontend/src/components/auth/sign-up.tsx
+++ b/frontend/src/components/auth/sign-up.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { signUp } from "../../lib/auth-client";
+import { track } from "@/lib/datafast";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "../ui/card";
@@ -30,6 +31,9 @@ export function SignUp() {
       return;
     }
 
+    track("signup_completed", {
+      auth_method: "email",
+    });
     setMessage("Account created successfully! Signing you in...");
     setLoading(false);
 

--- a/frontend/src/components/datafast-identity.tsx
+++ b/frontend/src/components/datafast-identity.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useSession } from "@/lib/auth-client";
+import { identify } from "@/lib/datafast";
+
+export function DataFastIdentity() {
+  const { data: session } = useSession();
+  const lastPayloadRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const user = session?.user;
+
+    if (!user?.id) {
+      lastPayloadRef.current = null;
+      return;
+    }
+
+    const payload = {
+      user_id: user.id,
+      ...(user.name ? { name: user.name } : {}),
+      ...(user.image ? { image: user.image } : {}),
+      is_admin: String(Boolean((user as { is_admin?: boolean }).is_admin)),
+    };
+    const serializedPayload = JSON.stringify(payload);
+
+    if (serializedPayload === lastPayloadRef.current) {
+      return;
+    }
+
+    identify(payload);
+    lastPayloadRef.current = serializedPayload;
+  }, [session?.user]);
+
+  return null;
+}

--- a/frontend/src/components/feedback-button.tsx
+++ b/frontend/src/components/feedback-button.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { MessageSquare, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useSession } from "@/lib/auth-client";
+import { track } from "@/lib/datafast";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -53,6 +54,9 @@ export function FeedbackButton() {
       }
 
       toast.success("Feedback submitted — thank you!");
+      track("feedback_submitted", {
+        category,
+      });
       setCategory("");
       setMessage("");
       setOpen(false);

--- a/frontend/src/components/landing-page.tsx
+++ b/frontend/src/components/landing-page.tsx
@@ -26,6 +26,7 @@ import {
   ExternalLink,
   CheckCircle,
 } from "lucide-react";
+import { track } from "@/lib/datafast";
 import { isLandingOnlyModeEnabled } from "@/lib/app-flags";
 
 function ScrollReveal({
@@ -165,6 +166,7 @@ export default function LandingPage() {
         throw new Error("Failed to join waitlist");
       }
 
+      track("waitlist_submitted");
       setWaitlistSubmitted(true);
       setEmail("");
     } catch (error) {

--- a/frontend/src/lib/datafast.ts
+++ b/frontend/src/lib/datafast.ts
@@ -1,0 +1,105 @@
+"use client";
+
+type DataFastValue = string | number | boolean | null | undefined;
+
+export type DataFastMetadata = Record<string, DataFastValue>;
+
+type DataFastIdentifyPayload = DataFastMetadata & {
+  user_id: string;
+};
+
+declare global {
+  interface Window {
+    datafast?: {
+      (...args: [string] | [string, Record<string, string>]): void;
+      q?: IArguments[];
+    };
+  }
+}
+
+const dataFastWebsiteId = process.env.NEXT_PUBLIC_DATAFAST_WEBSITE_ID;
+const dataFastDomain = process.env.NEXT_PUBLIC_DATAFAST_DOMAIN;
+
+const isClient = () => typeof window !== "undefined";
+
+export const isDataFastConfigured = Boolean(dataFastWebsiteId && dataFastDomain);
+
+const sanitizeKey = (key: string) =>
+  key
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .slice(0, 64);
+
+const sanitizeValue = (value: DataFastValue) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return String(value).slice(0, 255);
+};
+
+const sanitizeMetadata = (metadata?: DataFastMetadata) => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const sanitizedEntries = Object.entries(metadata)
+    .map(([key, value]) => {
+      const sanitizedKey = sanitizeKey(key);
+      const sanitizedValue = sanitizeValue(value);
+
+      if (!sanitizedKey || sanitizedValue === null) {
+        return null;
+      }
+
+      return [sanitizedKey, sanitizedValue] as const;
+    })
+    .filter((entry): entry is readonly [string, string] => entry !== null)
+    .slice(0, 10);
+
+  if (sanitizedEntries.length === 0) {
+    return undefined;
+  }
+
+  return Object.fromEntries(sanitizedEntries);
+};
+
+const sanitizeGoalName = (goalName: string) =>
+  goalName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]/g, "_")
+    .slice(0, 64);
+
+export function track(goalName: string, metadata?: DataFastMetadata) {
+  if (!isClient() || !isDataFastConfigured || !window.datafast) {
+    return;
+  }
+
+  const sanitizedGoalName = sanitizeGoalName(goalName);
+  if (!sanitizedGoalName) {
+    return;
+  }
+
+  const sanitizedMetadata = sanitizeMetadata(metadata);
+  if (sanitizedMetadata) {
+    window.datafast(sanitizedGoalName, sanitizedMetadata);
+    return;
+  }
+
+  window.datafast(sanitizedGoalName);
+}
+
+export function identify(metadata: DataFastIdentifyPayload) {
+  if (!isClient() || !isDataFastConfigured || !window.datafast) {
+    return;
+  }
+
+  const sanitizedMetadata = sanitizeMetadata(metadata);
+  if (!sanitizedMetadata?.user_id) {
+    return;
+  }
+
+  window.datafast("identify", sanitizedMetadata);
+}


### PR DESCRIPTION
## Summary
- add DataFast to the Next.js frontend with the official queue bootstrap and proxied script setup
- track the first product event set for auth, task creation, billing, feedback, preferences, and waitlist submission
- document the new DataFast env vars and verification steps in the README, setup guide, and configuration docs

## Testing
- npm run lint
- npm run build