### PR TITLE
fix(backend): support optional redis auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,6 +145,10 @@ POSTGRES_DB=supoclip
 POSTGRES_USER=supoclip
 POSTGRES_PASSWORD=supoclip_password
 
+# Redis password for Docker/local development.
+# Leave blank to run Redis without AUTH, or set a value to require authentication.
+REDIS_PASSWORD=
+
 # ==============================================
 # Docker Performance
 # ==============================================

--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -177,7 +177,7 @@ async def create_task(request: Request, db: AsyncSession = Depends(get_db)):
 
         # Save source metadata for resume/retries in environments without sources.url column
         redis_client = redis.Redis(
-            host=config.redis_host, port=config.redis_port, decode_responses=True
+            host=config.redis_host, port=config.redis_port, password=config.redis_password, decode_responses=True
         )
         try:
             await redis_client.set(
@@ -334,6 +334,7 @@ async def get_task_progress_sse(task_id: str, request: Request):
         redis_client = redis.Redis(
             host=runtime_config.redis_host,
             port=runtime_config.redis_port,
+            password=runtime_config.redis_password,
             decode_responses=True,
         )
 
@@ -691,7 +692,7 @@ async def cancel_task(
             return {"message": f"Task already in terminal state: {task.get('status')}"}
 
         redis_client = redis.Redis(
-            host=config.redis_host, port=config.redis_port, decode_responses=True
+            host=config.redis_host, port=config.redis_port, password=config.redis_password, decode_responses=True
         )
         try:
             await redis_client.setex(f"task_cancel:{task_id}", 3600, "1")
@@ -746,7 +747,7 @@ async def resume_task(
         add_subtitles = True
 
         redis_client = redis.Redis(
-            host=config.redis_host, port=config.redis_port, decode_responses=True
+            host=config.redis_host, port=config.redis_port, password=config.redis_password, decode_responses=True
         )
         try:
             source_payload = await redis_client.get(f"task_source:{task_id}")
@@ -769,7 +770,7 @@ async def resume_task(
             raise HTTPException(status_code=400, detail="Task source URL is missing")
 
         redis_client = redis.Redis(
-            host=config.redis_host, port=config.redis_port, decode_responses=True
+            host=config.redis_host, port=config.redis_port, password=config.redis_password, decode_responses=True
         )
         try:
             await redis_client.delete(f"task_cancel:{task_id}")
@@ -814,7 +815,7 @@ async def resume_task(
 async def list_dead_letter_tasks():
     """List tasks that exhausted retries and landed in dead-letter store."""
     redis_client = redis.Redis(
-        host=config.redis_host, port=config.redis_port, decode_responses=True
+        host=config.redis_host, port=config.redis_port, password=config.redis_password, decode_responses=True
     )
     try:
         ids_result = redis_client.smembers("tasks:dead_letter")

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -38,6 +38,7 @@ class Config:
         # Redis configuration
         self.redis_host = os.getenv("REDIS_HOST", "localhost")
         self.redis_port = int(os.getenv("REDIS_PORT", "6379"))
+        self.redis_password = self._get_optional_env("REDIS_PASSWORD")
 
         # Fail-safe: queued tasks should not stay queued forever
         self.queued_task_timeout_seconds = int(

--- a/backend/src/services/task_service.py
+++ b/backend/src/services/task_service.py
@@ -534,6 +534,7 @@ class TaskService:
         redis_client = redis.Redis(
             host=self.config.redis_host,
             port=self.config.redis_port,
+            password=self.config.redis_password,
             decode_responses=True,
         )
         try:

--- a/backend/src/workers/job_queue.py
+++ b/backend/src/workers/job_queue.py
@@ -17,7 +17,7 @@ FAST_QUEUE_NAME = "supoclip_fast"
 
 def _get_redis_settings() -> RedisSettings:
     config = get_config()
-    return RedisSettings(host=config.redis_host, port=config.redis_port, database=0)
+    return RedisSettings(host=config.redis_host, port=config.redis_port, password=config.redis_password, database=0)
 
 
 class JobQueue:

--- a/backend/src/workers/tasks.py
+++ b/backend/src/workers/tasks.py
@@ -129,7 +129,7 @@ class WorkerSettings:
 
     # Redis settings from environment
     redis_settings = RedisSettings(
-        host=config.redis_host, port=config.redis_port, database=0
+        host=config.redis_host, port=config.redis_port, password=config.redis_password, database=0
     )
 
     # Retry settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - TEMP_DIR=/app/uploads
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - ASSEMBLY_AI_API_KEY=${ASSEMBLY_AI_API_KEY}
       - APIFY_API_TOKEN=${APIFY_API_TOKEN}
       - APIFY_YOUTUBE_DEFAULT_QUALITY=${APIFY_YOUTUBE_DEFAULT_QUALITY:-1080}
@@ -133,6 +134,7 @@ services:
       - TEMP_DIR=/app/uploads
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - ASSEMBLY_AI_API_KEY=${ASSEMBLY_AI_API_KEY}
       - APIFY_API_TOKEN=${APIFY_API_TOKEN}
       - APIFY_YOUTUBE_DEFAULT_QUALITY=${APIFY_YOUTUBE_DEFAULT_QUALITY:-1080}
@@ -173,11 +175,23 @@ services:
     container_name: supoclip-redis
     ports:
       - "6379:6379"
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    command:
+      [
+        "sh",
+        "-c",
+        "if [ -n \"$${REDIS_PASSWORD}\" ]; then exec redis-server --requirepass \"$${REDIS_PASSWORD}\"; fi; exec redis-server",
+      ]
     volumes:
       - redis_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test:
+        [
+          "CMD-SHELL",
+          "if [ -n \"$${REDIS_PASSWORD}\" ]; then redis-cli -a \"$${REDIS_PASSWORD}\" ping; else redis-cli ping; fi",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
       [
         "sh",
         "-c",
-        "if [ -n \"$${REDIS_PASSWORD}\" ]; then exec redis-server --requirepass \"$${REDIS_PASSWORD}\"; fi; exec redis-server",
+        "if [ -n \"$${REDIS_PASSWORD}\" ]; then exec docker-entrypoint.sh redis-server --requirepass \"$${REDIS_PASSWORD}\"; fi; exec docker-entrypoint.sh redis-server",
       ]
     volumes:
       - redis_data:/data


### PR DESCRIPTION
## Summary
- add `REDIS_PASSWORD` support to backend and worker Redis clients
- make the Redis container optional-auth so `.env.example` still boots cleanly when the password is blank
- restore Redis host port exposure for local host-run backend, worker, and test workflows

## Verification
- ran `docker compose config`
- confirmed the rendered Redis service keeps port `6379` published and conditionally enables auth based on `REDIS_PASSWORD`
