### PR TITLE
fix(backend): ground clip transcripts to real spans

### DIFF
--- a/backend/src/ai.py
+++ b/backend/src/ai.py
@@ -15,6 +15,53 @@ from .config import Config
 
 logger = logging.getLogger(__name__)
 config = Config()
+TRANSCRIPT_LINE_PATTERN = re.compile(r"^\[(\d{2}:\d{2}) - (\d{2}:\d{2})\]\s*(.*)$")
+SPEAKER_PREFIX_PATTERN = re.compile(r"^Speaker [^:]+:\s*")
+
+
+def _normalize_transcript_text(value: str) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9']+", " ", value.lower())).strip()
+
+
+def _parse_transcript_lines(transcript: str) -> List[Dict[str, str]]:
+    lines: List[Dict[str, str]] = []
+    for raw_line in transcript.splitlines():
+        match = TRANSCRIPT_LINE_PATTERN.match(raw_line.strip())
+        if not match:
+            continue
+        line_text = SPEAKER_PREFIX_PATTERN.sub("", match.group(3).strip())
+        lines.append(
+            {
+                "start_time": match.group(1),
+                "end_time": match.group(2),
+                "text": line_text,
+            }
+        )
+    return lines
+
+
+def _extract_transcript_text_for_segment(
+    transcript_lines: List[Dict[str, str]],
+    start_time: str,
+    end_time: str,
+) -> Optional[str]:
+    for start_index, line in enumerate(transcript_lines):
+        if line["start_time"] != start_time:
+            continue
+
+        collected_parts = [line["text"]] if line["text"] else []
+        if line["end_time"] == end_time:
+            return " ".join(part for part in collected_parts if part).strip()
+
+        for next_line in transcript_lines[start_index + 1 :]:
+            if next_line["text"]:
+                collected_parts.append(next_line["text"])
+            if next_line["end_time"] == end_time:
+                return " ".join(part for part in collected_parts if part).strip()
+
+        return None
+
+    return None
 
 
 class ViralityAnalysis(BaseModel):
@@ -287,6 +334,7 @@ async def get_most_relevant_parts_by_transcript(
 
     try:
         agent = get_transcript_agent()
+        transcript_lines = _parse_transcript_lines(transcript)
 
         result = await agent.run(
             build_transcript_analysis_prompt(
@@ -337,6 +385,28 @@ async def get_most_relevant_parts_by_transcript(
                         f"Skipping segment too short: {duration}s (min 5s required)"
                     )
                     continue
+
+                grounded_text = _extract_transcript_text_for_segment(
+                    transcript_lines,
+                    segment.start_time,
+                    segment.end_time,
+                )
+                if grounded_text is None:
+                    logger.warning(
+                        "Skipping segment with timestamps not aligned to transcript lines: %s-%s",
+                        segment.start_time,
+                        segment.end_time,
+                    )
+                    continue
+                if _normalize_transcript_text(segment.text) != _normalize_transcript_text(
+                    grounded_text
+                ):
+                    logger.warning(
+                        "Adjusting segment text to transcript-backed span for %s-%s",
+                        segment.start_time,
+                        segment.end_time,
+                    )
+                    segment.text = grounded_text
 
                 # Validate virality scores
                 if segment.virality:

--- a/backend/src/migrations/sql/20260319_0002_generated_clips_task_order_unique.sql
+++ b/backend/src/migrations/sql/20260319_0002_generated_clips_task_order_unique.sql
@@ -1,0 +1,27 @@
+DELETE FROM generated_clips gc
+USING generated_clips newer
+WHERE gc.task_id = newer.task_id
+  AND gc.clip_order = newer.clip_order
+  AND (
+    gc.created_at < newer.created_at
+    OR (gc.created_at = newer.created_at AND gc.id < newer.id)
+  );
+
+UPDATE tasks t
+SET generated_clips_ids = sub.clip_ids,
+    updated_at = CURRENT_TIMESTAMP
+FROM (
+    SELECT task_id, ARRAY_AGG(id ORDER BY clip_order ASC, created_at ASC) AS clip_ids
+    FROM generated_clips
+    GROUP BY task_id
+) sub
+WHERE t.id = sub.task_id;
+
+UPDATE tasks
+SET generated_clips_ids = NULL,
+    updated_at = CURRENT_TIMESTAMP
+WHERE generated_clips_ids IS NOT NULL
+  AND id NOT IN (SELECT DISTINCT task_id FROM generated_clips);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_generated_clips_task_order
+ON generated_clips(task_id, clip_order);

--- a/backend/src/repositories/clip_repository.py
+++ b/backend/src/repositories/clip_repository.py
@@ -34,6 +34,18 @@ class ClipRepository:
         hook_type: Optional[str] = None,
     ) -> str:
         """Create a new clip record and return its ID."""
+        base_params = {
+            "task_id": task_id,
+            "filename": filename,
+            "file_path": file_path,
+            "start_time": start_time,
+            "end_time": end_time,
+            "duration": duration,
+            "text": text,
+            "relevance_score": relevance_score,
+            "reasoning": reasoning,
+            "clip_order": clip_order,
+        }
         try:
             result = await db.execute(
                 sa_text("""
@@ -47,19 +59,26 @@ class ClipRepository:
                      :text, :relevance_score, :reasoning, :clip_order,
                      :virality_score, :hook_score, :engagement_score, :value_score, :shareability_score, :hook_type,
                      NOW())
+                    ON CONFLICT (task_id, clip_order) DO UPDATE SET
+                        filename = EXCLUDED.filename,
+                        file_path = EXCLUDED.file_path,
+                        start_time = EXCLUDED.start_time,
+                        end_time = EXCLUDED.end_time,
+                        duration = EXCLUDED.duration,
+                        text = EXCLUDED.text,
+                        relevance_score = EXCLUDED.relevance_score,
+                        reasoning = EXCLUDED.reasoning,
+                        virality_score = EXCLUDED.virality_score,
+                        hook_score = EXCLUDED.hook_score,
+                        engagement_score = EXCLUDED.engagement_score,
+                        value_score = EXCLUDED.value_score,
+                        shareability_score = EXCLUDED.shareability_score,
+                        hook_type = EXCLUDED.hook_type,
+                        updated_at = NOW()
                     RETURNING id
                 """),
                 {
-                    "task_id": task_id,
-                    "filename": filename,
-                    "file_path": file_path,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                    "duration": duration,
-                    "text": text,
-                    "relevance_score": relevance_score,
-                    "reasoning": reasoning,
-                    "clip_order": clip_order,
+                    **base_params,
                     "virality_score": virality_score,
                     "hook_score": hook_score,
                     "engagement_score": engagement_score,
@@ -78,20 +97,19 @@ class ClipRepository:
                     VALUES
                     (:task_id, :filename, :file_path, :start_time, :end_time, :duration,
                      :text, :relevance_score, :reasoning, :clip_order, NOW())
+                    ON CONFLICT (task_id, clip_order) DO UPDATE SET
+                        filename = EXCLUDED.filename,
+                        file_path = EXCLUDED.file_path,
+                        start_time = EXCLUDED.start_time,
+                        end_time = EXCLUDED.end_time,
+                        duration = EXCLUDED.duration,
+                        text = EXCLUDED.text,
+                        relevance_score = EXCLUDED.relevance_score,
+                        reasoning = EXCLUDED.reasoning,
+                        updated_at = NOW()
                     RETURNING id
                 """),
-                {
-                    "task_id": task_id,
-                    "filename": filename,
-                    "file_path": file_path,
-                    "start_time": start_time,
-                    "end_time": end_time,
-                    "duration": duration,
-                    "text": text,
-                    "relevance_score": relevance_score,
-                    "reasoning": reasoning,
-                    "clip_order": clip_order,
-                },
+                base_params,
             )
         clip_id = result.scalar()
         if not clip_id:

--- a/backend/src/services/task_service.py
+++ b/backend/src/services/task_service.py
@@ -32,6 +32,7 @@ from ..clip_editor import (
 from ..video_utils import parse_timestamp_to_seconds
 
 logger = logging.getLogger(__name__)
+PROCESSING_CACHE_VERSION = "20260319_grounded_segments_v1"
 
 
 class TaskService:
@@ -48,7 +49,9 @@ class TaskService:
 
     @staticmethod
     def _build_cache_key(url: str, source_type: str, processing_mode: str) -> str:
-        payload = f"{source_type}|{processing_mode}|{url.strip()}"
+        payload = (
+            f"{PROCESSING_CACHE_VERSION}|{source_type}|{processing_mode}|{url.strip()}"
+        )
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
     def _is_stale_queued_task(self, task: Dict[str, Any]) -> bool:
@@ -224,6 +227,11 @@ class TaskService:
             total_clips = len(segments_to_render)
             clips_output_dir = Path(self.config.temp_dir) / "clips"
             clips_output_dir.mkdir(parents=True, exist_ok=True)
+
+            # Retries and regenerations should replace earlier clip rows instead of
+            # accumulating duplicates for the same task.
+            await self.clip_repo.delete_clips_by_task(self.db, task_id)
+            await self.task_repo.update_task_clips(self.db, task_id, [])
 
             clip_ids = []
             render_start = perf_counter()

--- a/backend/src/services/video_service.py
+++ b/backend/src/services/video_service.py
@@ -19,7 +19,9 @@ from ..video_utils import (
     get_video_transcript,
     create_clips_with_transitions,
     create_optimized_clip,
+    load_cached_transcript_data,
     parse_timestamp_to_seconds,
+    get_transcript_text_in_range,
 )
 from ..ai import get_most_relevant_parts_by_transcript
 from ..config import Config
@@ -31,6 +33,31 @@ UPLOAD_URL_PREFIX = "upload://"
 
 class VideoService:
     """Service for video processing operations."""
+
+    @staticmethod
+    def _ground_segment_text(
+        segment_payload: Dict[str, Any],
+        transcript_data: Optional[Dict[str, Any]],
+    ) -> str:
+        if not transcript_data:
+            return str(segment_payload.get("text") or "").strip()
+
+        start_time = str(segment_payload.get("start_time") or "").strip()
+        end_time = str(segment_payload.get("end_time") or "").strip()
+        if not start_time or not end_time:
+            return str(segment_payload.get("text") or "").strip()
+
+        start_seconds = parse_timestamp_to_seconds(start_time)
+        end_seconds = parse_timestamp_to_seconds(end_time)
+        if end_seconds <= start_seconds:
+            return str(segment_payload.get("text") or "").strip()
+
+        grounded_text = get_transcript_text_in_range(
+            transcript_data,
+            start_seconds,
+            end_seconds,
+        ).strip()
+        return grounded_text or str(segment_payload.get("text") or "").strip()
 
     @staticmethod
     def _get_file_duration(path: Path) -> Optional[float]:
@@ -365,27 +392,30 @@ class VideoService:
 
             raw_segments = relevant_parts.most_relevant_segments
             segments_json: List[Dict[str, Any]] = []
+            transcript_data = load_cached_transcript_data(video_path)
             for segment in raw_segments:
                 if isinstance(segment, dict):
-                    segments_json.append(
-                        {
-                            "start_time": segment.get("start_time"),
-                            "end_time": segment.get("end_time"),
-                            "text": segment.get("text", ""),
-                            "relevance_score": segment.get("relevance_score", 0.0),
-                            "reasoning": segment.get("reasoning", ""),
-                        }
-                    )
+                    segment_payload = {
+                        "start_time": segment.get("start_time"),
+                        "end_time": segment.get("end_time"),
+                        "text": segment.get("text", ""),
+                        "relevance_score": segment.get("relevance_score", 0.0),
+                        "reasoning": segment.get("reasoning", ""),
+                    }
                 else:
-                    segments_json.append(
-                        {
-                            "start_time": segment.start_time,
-                            "end_time": segment.end_time,
-                            "text": segment.text,
-                            "relevance_score": segment.relevance_score,
-                            "reasoning": segment.reasoning,
-                        }
-                    )
+                    segment_payload = {
+                        "start_time": segment.start_time,
+                        "end_time": segment.end_time,
+                        "text": segment.text,
+                        "relevance_score": segment.relevance_score,
+                        "reasoning": segment.reasoning,
+                    }
+
+                segment_payload["text"] = VideoService._ground_segment_text(
+                    segment_payload,
+                    transcript_data,
+                )
+                segments_json.append(segment_payload)
 
             if processing_mode == "fast":
                 segments_json = segments_json[: config.fast_mode_max_clips]

--- a/backend/src/video_utils.py
+++ b/backend/src/video_utils.py
@@ -26,6 +26,13 @@ from .font_registry import find_font_path
 logger = logging.getLogger(__name__)
 config = Config()
 TRANSCRIPT_CACHE_SCHEMA_VERSION = 2
+ANALYSIS_SEGMENT_MIN_WORDS = 8
+ANALYSIS_SEGMENT_MAX_WORDS = 8
+ANALYSIS_SEGMENT_MAX_DURATION_MS = 12_000
+ANALYSIS_LONG_UTTERANCE_MAX_WORDS = 24
+ANALYSIS_LONG_UTTERANCE_MAX_DURATION_MS = 20_000
+ANALYSIS_UTTERANCE_SPLIT_THRESHOLD_MS = 45_000
+ANALYSIS_UTTERANCE_SPLIT_THRESHOLD_WORDS = 80
 
 
 class VideoProcessor:
@@ -192,12 +199,107 @@ def _serialize_transcript_word(word) -> Dict[str, Any]:
     }
 
 
+def _join_transcript_tokens(tokens: List[str]) -> str:
+    text = " ".join(token.strip() for token in tokens if token and token.strip())
+    for before, after in (
+        (" ,", ","),
+        (" .", "."),
+        (" !", "!"),
+        (" ?", "?"),
+        (" ;", ";"),
+        (" :", ":"),
+        (" n't", "n't"),
+        (" 're", "'re"),
+        (" 've", "'ve"),
+        (" 'll", "'ll"),
+        (" 'd", "'d"),
+        (" 'm", "'m"),
+        (" 's", "'s"),
+    ):
+        text = text.replace(before, after)
+    return text.strip()
+
+
+def _format_words_for_analysis(
+    words: List[Any],
+    speaker: Optional[str] = None,
+    *,
+    min_words_per_segment: int = ANALYSIS_SEGMENT_MIN_WORDS,
+    max_words_per_segment: int = ANALYSIS_SEGMENT_MAX_WORDS,
+    max_duration_ms: int = ANALYSIS_SEGMENT_MAX_DURATION_MS,
+) -> List[str]:
+    if not words:
+        return []
+
+    formatted_lines: List[str] = []
+    current_words: List[Any] = []
+    current_start: Optional[int] = None
+
+    def flush_segment() -> None:
+        nonlocal current_words, current_start
+        if not current_words:
+            return
+        start_time = format_ms_to_timestamp(current_words[0].start)
+        end_time = format_ms_to_timestamp(current_words[-1].end)
+        text = _join_transcript_tokens([word.text for word in current_words])
+        if text:
+            speaker_prefix = f"Speaker {speaker}: " if speaker else ""
+            formatted_lines.append(f"[{start_time} - {end_time}] {speaker_prefix}{text}")
+        current_words = []
+        current_start = None
+
+    for word in words:
+        if current_start is None:
+            current_start = word.start
+
+        current_words.append(word)
+        duration_ms = word.end - current_start
+        segment_word_count = len(current_words)
+        ends_sentence = str(word.text).endswith((".", "!", "?"))
+
+        should_flush = False
+        if segment_word_count >= max_words_per_segment:
+            should_flush = True
+        elif (
+            ends_sentence
+            and segment_word_count >= min_words_per_segment
+        ):
+            should_flush = True
+        elif (
+            duration_ms >= max_duration_ms
+            and segment_word_count >= min_words_per_segment
+        ):
+            should_flush = True
+
+        if should_flush:
+            flush_segment()
+
+    flush_segment()
+    return formatted_lines
+
+
 def format_transcript_for_analysis(transcript) -> List[str]:
     """Format transcripts into readable timestamped segments for AI analysis."""
     utterances = getattr(transcript, "utterances", None) or []
     if utterances:
         formatted_lines = []
         for utterance in utterances:
+            utterance_words = list(getattr(utterance, "words", []) or [])
+            utterance_duration = max(0, int(utterance.end) - int(utterance.start))
+            if utterance_words and (
+                utterance_duration > ANALYSIS_UTTERANCE_SPLIT_THRESHOLD_MS
+                or len(utterance_words) > ANALYSIS_UTTERANCE_SPLIT_THRESHOLD_WORDS
+            ):
+                formatted_lines.extend(
+                    _format_words_for_analysis(
+                        utterance_words,
+                        getattr(utterance, "speaker", None),
+                        max_words_per_segment=ANALYSIS_LONG_UTTERANCE_MAX_WORDS,
+                        max_duration_ms=ANALYSIS_LONG_UTTERANCE_MAX_DURATION_MS,
+                    )
+                )
+                continue
+
             start_time = format_ms_to_timestamp(utterance.start)
             end_time = format_ms_to_timestamp(utterance.end)
             speaker = getattr(utterance, "speaker", None)
@@ -213,42 +315,7 @@ def format_transcript_for_analysis(transcript) -> List[str]:
         return formatted_lines
 
     logger.info(f"Processing {len(words)} words with precise timing")
-
-    current_segment = []
-    current_start = None
-    segment_word_count = 0
-    max_words_per_segment = 8
-
-    for word in words:
-        if current_start is None:
-            current_start = word.start
-
-        current_segment.append(word.text)
-        segment_word_count += 1
-
-        if (
-            segment_word_count >= max_words_per_segment
-            or word.text.endswith(".")
-            or word.text.endswith("!")
-            or word.text.endswith("?")
-        ):
-            if current_segment:
-                start_time = format_ms_to_timestamp(current_start)
-                end_time = format_ms_to_timestamp(word.end)
-                text = " ".join(current_segment)
-                formatted_lines.append(f"[{start_time} - {end_time}] {text}")
-
-            current_segment = []
-            current_start = None
-            segment_word_count = 0
-
-    if current_segment and current_start is not None:
-        start_time = format_ms_to_timestamp(current_start)
-        end_time = format_ms_to_timestamp(words[-1].end)
-        text = " ".join(current_segment)
-        formatted_lines.append(f"[{start_time} - {end_time}] {text}")
-
-    return formatted_lines
+    return _format_words_for_analysis(words)
 
 
 def format_ms_to_timestamp(ms: int) -> str:
@@ -699,6 +766,16 @@ def get_words_in_range(
                 )
 
     return relevant_words
+
+
+def get_transcript_text_in_range(
+    transcript_data: Dict, clip_start: float, clip_end: float
+) -> str:
+    """Return transcript text reconstructed from exact cached word timings."""
+    relevant_words = get_words_in_range(transcript_data, clip_start, clip_end)
+    if not relevant_words:
+        return ""
+    return _join_transcript_tokens([word["text"] for word in relevant_words])
 
 
 def create_assemblyai_subtitles(

--- a/backend/tests/test_video_utils_diarization.py
+++ b/backend/tests/test_video_utils_diarization.py
@@ -160,6 +160,70 @@ class VideoUtilsDiarizationTests(unittest.TestCase):
         self.assertIsNotNone(payload)
         self.assertEqual(payload["words"][0]["text"], "legacy")
 
+    def test_format_transcript_for_analysis_splits_long_diarized_utterances(self):
+        words = []
+        for index, token in enumerate(
+            [
+                "This",
+                "is",
+                "a",
+                "very",
+                "long",
+                "utterance",
+                "that",
+                "should",
+                "be",
+                "split",
+                "into",
+                "multiple",
+                "segments.",
+            ]
+        ):
+            start = index * 5000
+            words.append(
+                SimpleNamespace(
+                    text=token,
+                    start=start,
+                    end=start + 1500,
+                    confidence=0.99,
+                    speaker="A",
+                )
+            )
+
+        transcript = SimpleNamespace(
+            utterances=[
+                SimpleNamespace(
+                    start=0,
+                    end=65000,
+                    speaker="A",
+                    text=" ".join(word.text for word in words),
+                    words=words,
+                )
+            ],
+            words=words,
+        )
+
+        formatted = video_utils.format_transcript_for_analysis(transcript)
+
+        self.assertGreater(len(formatted), 1)
+        self.assertEqual(
+            formatted[0],
+            "[00:00 - 00:36] Speaker A: This is a very long utterance that should",
+        )
+
+    def test_get_transcript_text_in_range_reconstructs_exact_words(self):
+        transcript_data = {
+            "words": [
+                {"text": "Hello", "start": 0, "end": 400, "confidence": 1.0},
+                {"text": "world.", "start": 401, "end": 900, "confidence": 1.0},
+                {"text": "Again", "start": 901, "end": 1300, "confidence": 1.0},
+            ]
+        }
+
+        text = video_utils.get_transcript_text_in_range(transcript_data, 0.0, 0.95)
+
+        self.assertEqual(text, "Hello world. Again")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/unit/test_ai_grounding.py
+++ b/backend/tests/unit/test_ai_grounding.py
@@ -1,0 +1,30 @@
+from src.ai import _extract_transcript_text_for_segment, _parse_transcript_lines
+
+
+def test_extract_transcript_text_for_segment_strips_speaker_labels_and_joins_lines():
+    transcript = "\n".join(
+        [
+            "[00:00 - 00:10] Speaker A: First sentence.",
+            "[00:10 - 00:20] Speaker A: Second sentence.",
+        ]
+    )
+
+    transcript_lines = _parse_transcript_lines(transcript)
+    grounded_text = _extract_transcript_text_for_segment(
+        transcript_lines,
+        "00:00",
+        "00:20",
+    )
+
+    assert grounded_text == "First sentence. Second sentence."
+
+
+def test_extract_transcript_text_for_segment_rejects_non_boundary_timestamp():
+    transcript = "[00:00 - 00:10] Speaker A: First sentence."
+
+    transcript_lines = _parse_transcript_lines(transcript)
+
+    assert (
+        _extract_transcript_text_for_segment(transcript_lines, "00:05", "00:10")
+        is None
+    )

--- a/backend/tests/unit/test_task_service.py
+++ b/backend/tests/unit/test_task_service.py
@@ -65,6 +65,7 @@ def build_task_service() -> TaskService:
     service.task_repo.update_task_runtime_metadata = AsyncMock()
     service.task_repo.update_task_status = AsyncMock()
     service.task_repo.update_task_clips = AsyncMock()
+    service.clip_repo.delete_clips_by_task = AsyncMock(return_value=0)
     service.clip_repo.create_clip = AsyncMock(return_value="clip-1")
     service.video_service.create_single_clip = AsyncMock(return_value=build_clip_result())
     service.video_service.apply_single_transition = AsyncMock(
@@ -234,6 +235,33 @@ async def test_process_task_keeps_generated_clips_standalone():
         for call in service.clip_repo.create_clip.await_args_list
     ]
     assert saved_paths == ["/tmp/clip-1.mp4", "/tmp/clip-2.mp4"]
+
+
+@pytest.mark.asyncio
+async def test_process_task_clears_existing_clips_before_rendering():
+    service = build_task_service()
+    service.task_repo.get_task_notification_context = AsyncMock(
+        return_value={
+            "notify_on_completion": False,
+            "completion_notification_sent_at": None,
+            "source_title": "Demo video",
+            "user_email": "user@example.com",
+            "user_name": "Demo User",
+            "user_first_name": "Demo",
+        }
+    )
+
+    await service.process_task(
+        task_id="task-1",
+        url="https://www.youtube.com/watch?v=demo",
+        source_type="youtube",
+    )
+
+    service.clip_repo.delete_clips_by_task.assert_awaited_once_with(service.db, "task-1")
+    assert any(
+        call.args == (service.db, "task-1", [])
+        for call in service.task_repo.update_task_clips.await_args_list
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- split long diarized transcript utterances into smaller analysis spans before asking the LLM to pick clips
- validate AI-selected clip ranges against real transcript boundaries and rebuild clip text from cached word timings
- make clip writes retry-safe by replacing existing task clips and enforcing uniqueness on `(task_id, clip_order)` via migration

## Why
Production task `c81b75a1-4204-4fa0-b236-ab7b5d29ec97` showed a bad Clip 1 transcript: the saved `generated_clips.text` came from a different point in the lecture than the actual `24:51-26:11` clip audio. The root cause was coarse transcript spans plus loose AI validation. The same task also duplicated clip rows on retry.

## Verification
- `cd backend && uv run pytest --no-cov tests/test_video_utils_diarization.py tests/unit/test_ai_grounding.py tests/unit/test_task_service.py`

## Notes
- bumps the processing cache key version so old cached analysis payloads are bypassed
- adds a migration to dedupe existing duplicate clip orders before creating the unique index