### PR TITLE
Backend refactor: module splits, test coverage 38%→49%, security hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Local app commands:
 - `cd frontend && npm run dev` (or `waitlist`): run Next.js in dev mode.
 - `cd frontend && npm run build && npm run start`: production build + serve.
 - `cd frontend && npm run lint` (same in `waitlist`): run ESLint.
-- `cd backend && uv sync && uvicorn src.main:app --reload --host 0.0.0.0 --port 8000`: run API locally.
+- `cd backend && uv sync && uvicorn src.main_refactored:app --reload --host 0.0.0.0 --port 8000`: run API locally.
 - `cd backend && .venv/bin/arq src.workers.tasks.WorkerSettings`: run the worker.
 
 ## Coding Style & Naming Conventions
@@ -28,11 +28,16 @@ Local app commands:
 - Imports: use the `@/*` alias in Next.js apps when possible.
 
 ## Testing Guidelines
-There is no mature automated test suite yet. Treat linting plus manual verification as the current baseline:
-- Run `npm run lint` in both Next.js apps.
-- Smoke test core flows with `docker-compose` (create task, process clips, view task page).
+Backend now has a growing pytest suite (418 passed, ~49% line coverage):
+- `cd backend && uv run pytest` — full local suite (integration tests are
+  skipped without a reachable Postgres)
+- Integration tests (`tests/integration/`) hit real DB. The host port is not
+  exposed; run inside the backend container:
+  `docker exec supoclip-backend bash -c "cd /app && DATABASE_URL='postgresql+asyncpg://supoclip:supoclip_password@postgres:5432/supoclip' .venv/bin/python -m pytest tests/integration/"`
+- Frontend: `npm run lint` + manual smoke via `docker-compose`.
 
-When adding tests, place them near code or under `tests/` with clear names (`test_*.py`, `*.test.ts[x]`).
+Place new tests under `backend/tests/{unit,integration}/` with `test_*.py`
+names, or next to frontend code as `*.test.ts[x]`.
 
 ## Commit & Pull Request Guidelines
 Recent history favors short imperative commit subjects (`Add list endpoint`, `Fix typo`, `improve UX`). Prefer:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,35 @@ bun install          # Uses bun, not npm
 bun run dev
 ```
 
-### No tests
+### Tests
 
-The project currently has no test files.
+Backend tests live in `backend/tests/` (unit + integration). Run with:
+
+```bash
+cd backend
+uv run pytest                       # All tests
+uv run pytest tests/unit/           # Unit only
+uv run pytest -k test_task_service  # Single file by keyword
+```
+
+**Integration tests** require PostgreSQL. The local host port is not exposed by
+`docker-compose.yml`, so run inside the running backend container:
+
+```bash
+docker exec supoclip-backend bash -c "cd /app && \
+  DATABASE_URL='postgresql+asyncpg://supoclip:supoclip_password@postgres:5432/supoclip' \
+  .venv/bin/python -m pytest tests/integration/"
+```
+
+Integration scenarios cover the guard-rail layers of `/tasks/*` endpoints
+(auth, 404, 403, Pydantic validation) — not the ffmpeg/MoviePy pipeline.
+
+Current state: 418 passed, 49% line coverage. 100% covered: `_task_helpers`,
+`_video_helpers`, `_youtube_io`, `_youtube_downloader`, `caption_templates`,
+`observability`, `pricing`, `subtitle_exporters`, `usage_context`,
+`utils/async_helpers`.
+
+Frontend has Vitest + Playwright configured in `package.json` but no test files yet.
 
 ## Architecture
 
@@ -72,7 +98,7 @@ Task creation returns immediately (<100ms). Video processing happens asynchronou
 
 ### Backend: Layered Architecture
 
-The backend was refactored from monolithic (`main.py`, legacy) to layered (`main_refactored.py`, active):
+The backend uses a layered architecture (`main_refactored.py` is the entry point; the old monolithic `main.py` was removed):
 
 ```
 api/routes/          → HTTP handlers (tasks.py, media.py)
@@ -126,21 +152,25 @@ PostgreSQL 15. Schema in `init.sql`. Mixed naming conventions:
 
 | File | Purpose |
 |------|---------|
-| `src/main_refactored.py` | Active FastAPI entry point (129 lines) |
-| `src/main.py` | Legacy monolithic entry point (do not use for new work) |
-| `src/api/routes/tasks.py` | Task CRUD, SSE progress, clip editing endpoints (711 lines) |
+| `src/main_refactored.py` | Active FastAPI entry point (240 lines) |
+| `src/api/routes/tasks/` | Task route package: lifecycle, clips, export, admin (split from a 936-line module) |
 | `src/api/routes/media.py` | Fonts, transitions, uploads, templates |
-| `src/services/task_service.py` | Task orchestration, clip editing logic (574 lines) |
+| `src/services/task_service.py` | Task orchestration + `process_task` (~482 lines). Clip-editing in `_clip_edit_mixin.py`, completion-email in `_task_notification_mixin.py`, pure helpers (cache-key/mmss/stale-check) in `_task_helpers.py` |
 | `src/services/video_service.py` | Video download, transcription, AI analysis, clip generation |
 | `src/workers/tasks.py` | ARQ worker task definitions |
 | `src/workers/job_queue.py` | Job queue management |
 | `src/workers/progress.py` | Real-time progress via Redis |
 | `src/ai.py` | Pydantic AI agents, system prompt, segment validation |
-| `src/video_utils.py` | Video processing, cropping, subtitles (~820 lines) |
+| `src/video_utils.py` | Thin entry point (~388 lines) + re-exports. Submodules: `_video_encoder.py` (VideoProcessor + font resolver), `_video_helpers.py` (timestamp/sizing/word helpers), `_video_transitions.py` (apply_transition_effect + listing), `_video_face.py` (face detection), `_video_broll.py` (B-roll/9:16), `_video_subtitles.py` (5 subtitle styles), `_video_transcript.py` (AssemblyAI transcription + caching). Subtitle/transcript/transitions submodules use `from . import video_utils as _vu` at call time to preserve `patch("src.video_utils.*")` compat |
+| `src/youtube_utils.py` | YouTube fetch/download entry point (~423 lines). Submodules: `_youtube_parsers.py` (URL/ISO-8601 parsers), `_youtube_io.py` (ffprobe + cache helpers), `_youtube_downloader.py` (yt-dlp option presets) |
+| `src/api/routes/tasks/schemas.py` | Pydantic request schemas for `/tasks/*` endpoints: `CreateTaskRequest`, `TaskSettingsRequest`, `ClipTrimRequest`, `ClipSplitRequest`, `ClipMergeRequest`, `ClipCaptionsRequest`, `ClipRegenerateRequest`. Invalid input returns 422 before reaching the service layer |
 | `src/clip_editor.py` | Clip trim, split, merge, export presets |
 | `src/broll.py` | Pexels API B-roll integration |
 | `src/caption_templates.py` | Caption template system |
 | `src/config.py` | Environment variable configuration |
+| `src/font_registry.py` | Font discovery + variant detection. `find_font_path` rejects path-traversal payloads (`..`, `/`, `\`, `\x00`) and verifies resolved paths stay under the font search directories (`_is_path_inside`) |
+
+> Legacy `src/main.py` was removed; `main_refactored.py` is the sole entry point.
 
 ## API Endpoints (routes in `api/routes/`)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "moviepy>=2.2.1",
     "opencv-python>=4.8.0",
     "srt-equalizer>=0.1.10",
-    "assemblyai>=0.35.0",
+    "assemblyai>=0.62.0",
     "srt>=3.5.3",
     "mediapipe>=0.10.0",
     "numpy>=1.24.0",
@@ -31,6 +31,7 @@ dependencies = [
     "redis>=5.0.0",
     "resend>=2.13.0",
     "requests>=2.32.0",
+    "cryptography>=42.0.0",
 ]
 
 [dependency-groups]
@@ -49,9 +50,26 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 testpaths = ["tests"]
 addopts = """
---cov=src.auth_headers
---cov=src.services.billing_service
---cov-report=term-missing
+--cov=src
+--cov-report=term-missing:skip-covered
 --cov-report=html
---cov-fail-under=65
+--cov-fail-under=45
 """
+
+[tool.coverage.run]
+branch = false
+source = ["src"]
+omit = [
+    # Entrypoints not exercised by unit tests — the uvicorn/arq processes
+    # drive these, so they only run under full Docker smoke.
+    "src/worker_main.py",
+    "src/workers/tasks.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+]

--- a/backend/src/_video_encoder.py
+++ b/backend/src/_video_encoder.py
@@ -1,0 +1,104 @@
+"""Video encoder + font resolver helpers extracted from ``video_utils.py``.
+
+Keep this module import-cheap; ``video_utils`` re-exports ``VideoProcessor`` and
+``_resolve_font_with_style`` so ``patch("src.video_utils.VideoProcessor")`` in
+existing tests continues to work.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+import logging
+
+from .font_registry import detect_variants, find_font_path
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_font_with_style(
+    font_family: str, bold: bool = False, italic: bool = False
+) -> Optional[Path]:
+    """Resolve a font path, preferring Bold/Italic sibling files when available."""
+    base_path = find_font_path(font_family, allow_all_user_fonts=True)
+    if not base_path:
+        return None
+
+    if not bold and not italic:
+        return base_path
+
+    variants = detect_variants(base_path)
+
+    if bold and italic:
+        if variants.get("bold_path"):
+            return Path(variants["bold_path"])
+        if variants.get("italic_path"):
+            return Path(variants["italic_path"])
+    elif bold and variants.get("bold_path"):
+        return Path(variants["bold_path"])
+    elif italic and variants.get("italic_path"):
+        return Path(variants["italic_path"])
+
+    if bold or italic:
+        logger.info(
+            f"Font '{font_family}' has no bold/italic variant; using base font "
+            f"(bold={bold}, italic={italic})"
+        )
+
+    return base_path
+
+
+class VideoProcessor:
+    """Handles video processing operations with optimized settings."""
+
+    def __init__(
+        self,
+        font_family: str = "THEBOLDFONT",
+        font_size: int = 24,
+        font_color: str = "#FFFFFF",
+        bold: bool = False,
+        italic: bool = False,
+    ):
+        self.font_family = font_family
+        self.font_size = font_size
+        self.font_color = font_color
+        self.bold = bool(bold)
+        self.italic = bool(italic)
+        resolved_font = _resolve_font_with_style(font_family, bold=self.bold, italic=self.italic)
+        if not resolved_font:
+            resolved_font = find_font_path("TikTokSans-Regular")
+        if not resolved_font:
+            resolved_font = find_font_path("THEBOLDFONT")
+        self.font_path = str(resolved_font) if resolved_font else ""
+
+    def get_optimal_encoding_settings(
+        self, target_quality: str = "high"
+    ) -> Dict[str, Any]:
+        """Get optimal encoding settings for different quality levels."""
+        settings = {
+            "high": {
+                "codec": "libx264",
+                "audio_codec": "aac",
+                "audio_bitrate": "256k",
+                "preset": "slow",
+                "ffmpeg_params": [
+                    "-crf",
+                    "18",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-profile:v",
+                    "high",
+                    "-movflags",
+                    "+faststart",
+                    "-sws_flags",
+                    "lanczos",
+                ],
+            },
+            "medium": {
+                "codec": "libx264",
+                "audio_codec": "aac",
+                "bitrate": "4000k",
+                "audio_bitrate": "192k",
+                "preset": "fast",
+                "ffmpeg_params": ["-crf", "23", "-pix_fmt", "yuv420p"],
+            },
+        }
+        return settings.get(target_quality, settings["high"])

--- a/backend/src/_video_helpers.py
+++ b/backend/src/_video_helpers.py
@@ -1,0 +1,143 @@
+"""Sizing/timestamp/word helpers extracted from ``video_utils.py``.
+
+``video_utils`` re-exports each symbol so existing test patches
+(e.g. ``patch("src.video_utils.get_scaled_font_size")``) continue to work.
+"""
+
+from typing import Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def format_ms_to_timestamp(ms: int) -> str:
+    """Format milliseconds to MM:SS format."""
+    seconds = ms // 1000
+    minutes = seconds // 60
+    seconds = seconds % 60
+    return f"{minutes:02d}:{seconds:02d}"
+
+
+def round_to_even(value: int) -> int:
+    """Round integer to nearest even number for H.264 compatibility."""
+    return value - (value % 2)
+
+
+def get_scaled_font_size(base_font_size: int, video_width: int) -> int:
+    """Scale caption font size by output width with sensible bounds."""
+    scaled_size = int(base_font_size * (video_width / 720))
+    return max(24, min(64, scaled_size))
+
+
+def get_subtitle_max_width(video_width: int) -> int:
+    """Return max subtitle text width with horizontal safe margins."""
+    horizontal_padding = max(40, int(video_width * 0.06))
+    return max(200, video_width - (horizontal_padding * 2))
+
+
+def get_safe_vertical_position(
+    video_height: int, text_height: int, position_y: float
+) -> int:
+    """Return subtitle y position clamped inside a top/bottom safe area."""
+    min_top_padding = max(40, int(video_height * 0.05))
+    min_bottom_padding = max(120, int(video_height * 0.10))
+
+    desired_y = int(video_height * position_y - text_height // 2)
+    max_y = video_height - min_bottom_padding - text_height
+    return max(min_top_padding, min(desired_y, max_y))
+
+
+def parse_timestamp_to_seconds(timestamp_str: str) -> float:
+    """Parse timestamp string to seconds."""
+    try:
+        timestamp_str = timestamp_str.strip()
+        logger.info(f"Parsing timestamp: '{timestamp_str}'")
+
+        if ":" in timestamp_str:
+            parts = timestamp_str.split(":")
+            if len(parts) == 2:
+                minutes, seconds = map(int, parts)
+                result = minutes * 60 + seconds
+                logger.info(f"Parsed '{timestamp_str}' -> {result}s")
+                return result
+            elif len(parts) == 3:
+                hours, minutes, seconds = map(int, parts)
+                result = hours * 3600 + minutes * 60 + seconds
+                logger.info(f"Parsed '{timestamp_str}' -> {result}s")
+                return result
+
+        result = float(timestamp_str)
+        logger.info(f"Parsed '{timestamp_str}' as seconds -> {result}s")
+        return result
+
+    except (ValueError, IndexError) as e:
+        logger.error(f"Failed to parse timestamp '{timestamp_str}': {e}")
+        return 0.0
+
+
+def get_words_in_range(
+    transcript_data: Dict, clip_start: float, clip_end: float
+) -> List[Dict]:
+    """Extract words that fall within a clip timerange."""
+    if not transcript_data or not transcript_data.get("words"):
+        return []
+
+    clip_start_ms = int(clip_start * 1000)
+    clip_end_ms = int(clip_end * 1000)
+
+    relevant_words = []
+    for word_data in transcript_data["words"]:
+        word_start = word_data["start"]
+        word_end = word_data["end"]
+
+        if word_start < clip_end_ms and word_end > clip_start_ms:
+            relative_start = max(0, (word_start - clip_start_ms) / 1000.0)
+            relative_end = min(
+                (clip_end_ms - clip_start_ms) / 1000.0,
+                (word_end - clip_start_ms) / 1000.0,
+            )
+
+            if relative_end > relative_start:
+                relevant_words.append(
+                    {
+                        "text": word_data["text"],
+                        "start": relative_start,
+                        "end": relative_end,
+                        "confidence": word_data.get("confidence", 1.0),
+                        "speaker": word_data.get("speaker"),
+                    }
+                )
+
+    return relevant_words
+
+
+def _chunk_words_by_speaker(
+    words: List[Dict], max_per_group: int
+) -> List[List[Dict]]:
+    """Group consecutive words, breaking at speaker changes or max group size.
+
+    Prevents two speakers from being rendered in a single subtitle line. When
+    diarization data is missing (speaker=None for all words) this behaves
+    identically to a fixed-size chunker.
+    """
+    if not words or max_per_group <= 0:
+        return []
+
+    groups: List[List[Dict]] = []
+    current: List[Dict] = []
+    current_speaker = words[0].get("speaker")
+
+    for word in words:
+        speaker = word.get("speaker")
+        if current and (speaker != current_speaker or len(current) >= max_per_group):
+            groups.append(current)
+            current = []
+            current_speaker = speaker
+        if not current:
+            current_speaker = speaker
+        current.append(word)
+
+    if current:
+        groups.append(current)
+
+    return groups

--- a/backend/src/_video_transitions.py
+++ b/backend/src/_video_transitions.py
@@ -1,0 +1,120 @@
+"""Transition helpers extracted from ``video_utils.py``.
+
+``apply_transition_effect`` re-imports the MoviePy symbols inside the function
+body on purpose: tests patch them via ``moviepy.VideoFileClip`` etc.
+``VideoProcessor`` is routed through ``video_utils`` so
+``patch("src.video_utils.VideoProcessor")`` keeps working.
+"""
+
+from pathlib import Path
+from typing import List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_available_transitions() -> List[str]:
+    """Get list of available transition video files."""
+    transitions_dir = Path(__file__).parent.parent / "transitions"
+    if not transitions_dir.exists():
+        logger.warning("Transitions directory not found")
+        return []
+
+    transition_files = []
+    for file_path in transitions_dir.glob("*.mp4"):
+        transition_files.append(str(file_path))
+
+    logger.info(f"Found {len(transition_files)} transition files")
+    return transition_files
+
+
+def apply_transition_effect(
+    clip1_path: Path, clip2_path: Path, transition_path: Path, output_path: Path
+) -> bool:
+    """Apply transition effect between two clips using a transition video."""
+    from moviepy import VideoFileClip, CompositeVideoClip, concatenate_videoclips
+    from moviepy.video.fx import FadeIn, FadeOut
+    from . import video_utils as _vu
+
+    clip1 = None
+    clip2 = None
+    transition = None
+    clip1_tail = None
+    clip2_intro = None
+    clip2_remainder = None
+    intro_segment = None
+    final_clip = None
+
+    try:
+        clip1 = VideoFileClip(str(clip1_path))
+        clip2 = VideoFileClip(str(clip2_path))
+        transition = VideoFileClip(str(transition_path))
+
+        transition_duration = min(1.5, transition.duration, clip1.duration, clip2.duration)
+        if transition_duration <= 0:
+            logger.warning("Transition duration is zero, skipping transition effect")
+            return False
+
+        transition = transition.subclipped(0, transition_duration)
+
+        clip_size = clip2.size
+        transition = transition.resized(clip_size)
+
+        clip1_tail_start = max(0, clip1.duration - transition_duration)
+        clip1_tail = clip1.subclipped(clip1_tail_start, clip1.duration).with_effects(
+            [FadeOut(transition_duration)]
+        )
+        clip2_intro = clip2.subclipped(0, transition_duration).with_effects(
+            [FadeIn(transition_duration)]
+        )
+
+        intro_segment = CompositeVideoClip(
+            [clip1_tail, clip2_intro, transition], size=clip_size
+        ).with_duration(transition_duration)
+        if clip2_intro.audio is not None:
+            intro_segment = intro_segment.with_audio(clip2_intro.audio)
+
+        final_segments = [intro_segment]
+        if clip2.duration > transition_duration:
+            clip2_remainder = clip2.subclipped(transition_duration, clip2.duration)
+            final_segments.append(clip2_remainder)
+
+        final_clip = (
+            concatenate_videoclips(final_segments, method="compose")
+            if len(final_segments) > 1
+            else intro_segment
+        )
+
+        processor = _vu.VideoProcessor()
+        encoding_settings = processor.get_optimal_encoding_settings("high")
+
+        final_clip.write_videofile(
+            str(output_path),
+            temp_audiofile="temp-audio.m4a",
+            remove_temp=True,
+            logger=None,
+            **encoding_settings,
+        )
+
+        logger.info(f"Applied transition effect: {output_path}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Error applying transition effect: {e}")
+        return False
+    finally:
+        for clip in (
+            final_clip,
+            intro_segment,
+            clip2_remainder,
+            clip2_intro,
+            clip1_tail,
+            transition,
+            clip2,
+            clip1,
+        ):
+            if clip is not None:
+                try:
+                    clip.close()
+                except Exception:
+                    pass

--- a/backend/src/_youtube_downloader.py
+++ b/backend/src/_youtube_downloader.py
@@ -1,0 +1,58 @@
+"""``YouTubeDownloader`` extracted from ``youtube_utils.py``.
+
+Holds yt-dlp option presets. Re-exported by ``youtube_utils`` for callers that
+still import it from there.
+"""
+
+from pathlib import Path
+from typing import Any, Dict
+
+from .config import get_config
+
+
+class YouTubeDownloader:
+    """Enhanced YouTube downloader with optimized settings."""
+
+    def __init__(self):
+        self.temp_dir = Path(get_config().temp_dir)
+        self.temp_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_optimal_download_options(
+        self,
+        video_id: str,
+    ) -> Dict[str, Any]:
+        """Get optimal yt-dlp options for high-quality downloads."""
+        output_path = self.temp_dir / f"{video_id}.%(ext)s"
+
+        opts = {
+            "outtmpl": str(output_path),
+            # Use best available video/audio to avoid quality caps from container constraints.
+            "format": "bestvideo*+bestaudio/best",
+            "format_sort": ["res", "fps"],
+            "merge_output_format": "mp4",
+            "writesubtitles": False,
+            "writeautomaticsub": False,
+            "noplaylist": True,
+            "overwrites": True,
+            "socket_timeout": 30,
+            "retries": 5,
+            "fragment_retries": 5,
+            "http_chunk_size": 10485760,  # 10MB chunks
+            "quiet": True,
+            "no_warnings": False,
+            "ignoreerrors": False,
+            "http_headers": {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+                "Accept-Language": "en-US,en;q=0.9",
+                "Accept-Encoding": "gzip, deflate",
+                "Connection": "keep-alive",
+            },
+            "extract_flat": False,
+            "writeinfojson": False,
+            "nocheckcertificate": True,
+            "prefer_insecure": False,
+            "age_limit": None,
+        }
+
+        return opts

--- a/backend/src/_youtube_io.py
+++ b/backend/src/_youtube_io.py
@@ -1,0 +1,91 @@
+"""Filesystem + subprocess helpers extracted from ``youtube_utils.py``."""
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def _build_info_options() -> Dict[str, Any]:
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "extractaudio": False,
+        "skip_download": True,
+        "socket_timeout": 30,
+        "http_headers": {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Connection": "keep-alive",
+        },
+        "nocheckcertificate": True,
+    }
+    return ydl_opts
+
+
+def _empty_video_info(video_id: Optional[str] = None) -> Dict[str, Any]:
+    return {
+        "id": video_id,
+        "title": None,
+        "description": "",
+        "duration": None,
+        "uploader": None,
+        "upload_date": None,
+        "view_count": None,
+        "like_count": None,
+        "thumbnail": None,
+        "format_id": None,
+        "resolution": None,
+        "fps": None,
+        "filesize": None,
+    }
+
+
+def _get_local_video_dimensions(path: Path) -> tuple[int, int]:
+    """Return local video width/height using ffprobe."""
+    try:
+        command = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height",
+            "-of",
+            "csv=s=x:p=0",
+            str(path),
+        ]
+        result = subprocess.run(command, capture_output=True, text=True, check=True)
+        output = result.stdout.strip()
+        if not output or "x" not in output:
+            return (0, 0)
+        width_str, height_str = output.split("x", 1)
+        return (int(width_str), int(height_str))
+    except Exception:
+        return (0, 0)
+
+
+def _remove_cached_downloads(temp_dir: Path, video_id: str) -> None:
+    cached_files = [
+        file_path
+        for file_path in temp_dir.glob(f"{video_id}.*")
+        if file_path.is_file()
+        and file_path.suffix.lower() in [".mp4", ".mkv", ".webm", ".mov", ".m4v"]
+    ]
+    if not cached_files:
+        return
+
+    logger.info(
+        "Refreshing download for %s (found %s cached file(s))",
+        video_id,
+        len(cached_files),
+    )
+    for cached_file in cached_files:
+        try:
+            cached_file.unlink()
+        except Exception as exc:
+            logger.warning("Failed to remove stale cache file %s: %s", cached_file, exc)

--- a/backend/src/_youtube_parsers.py
+++ b/backend/src/_youtube_parsers.py
@@ -1,0 +1,117 @@
+"""YouTube URL + metadata parsers extracted from ``youtube_utils.py``.
+
+Pure functions; no IO. ``youtube_utils`` re-exports ``get_youtube_video_id`` and
+``validate_youtube_url`` so external callers keep their existing import paths.
+"""
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+YOUTUBE_METADATA_PROVIDER_YTDLP = "yt_dlp"
+YOUTUBE_METADATA_PROVIDER_DATA_API = "youtube_data_api"
+YOUTUBE_DATA_API_URL = "https://www.googleapis.com/youtube/v3/videos"
+
+
+def _parse_iso8601_duration_to_seconds(value: str) -> int:
+    match = re.fullmatch(
+        r"P(?:(?P<days>\d+)D)?(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?)?",
+        value or "",
+    )
+    if not match:
+        raise ValueError(f"Unsupported ISO 8601 duration: {value}")
+
+    days = int(match.group("days") or 0)
+    hours = int(match.group("hours") or 0)
+    minutes = int(match.group("minutes") or 0)
+    seconds = int(match.group("seconds") or 0)
+    return (((days * 24) + hours) * 60 + minutes) * 60 + seconds
+
+
+def _pick_best_thumbnail(thumbnails: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not thumbnails:
+        return None
+
+    for key in ("maxres", "standard", "high", "medium", "default"):
+        candidate = thumbnails.get(key)
+        if isinstance(candidate, dict) and candidate.get("url"):
+            return candidate["url"]
+
+    for candidate in thumbnails.values():
+        if isinstance(candidate, dict) and candidate.get("url"):
+            return candidate["url"]
+
+    return None
+
+
+def _normalize_upload_date(published_at: Optional[str]) -> Optional[str]:
+    if not published_at:
+        return None
+
+    try:
+        return (
+            datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+            .strftime("%Y%m%d")
+        )
+    except ValueError:
+        logger.warning("Could not parse YouTube publishedAt value: %s", published_at)
+        return None
+
+
+def _parse_optional_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_youtube_video_id(url: str) -> Optional[str]:
+    """
+    Extract YouTube video ID from various URL formats.
+    Supports standard, short, embed, and mobile URLs.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return None
+
+    url = url.strip()
+
+    patterns = [
+        r"(?:youtube\.com/(?:.*v=|v/|embed/|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})",
+        r"youtube\.com/watch\?v=([A-Za-z0-9_-]{11})",
+        r"youtube\.com/embed/([A-Za-z0-9_-]{11})",
+        r"youtube\.com/v/([A-Za-z0-9_-]{11})",
+        r"youtu\.be/([A-Za-z0-9_-]{11})",
+        r"youtube\.com/shorts/([A-Za-z0-9_-]{11})",
+        r"m\.youtube\.com/watch\?v=([A-Za-z0-9_-]{11})",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, url, re.IGNORECASE)
+        if match:
+            video_id = match.group(1)
+            if len(video_id) == 11:
+                return video_id
+
+    try:
+        parsed_url = urlparse(url)
+        if "youtube.com" in parsed_url.netloc.lower():
+            query = parse_qs(parsed_url.query)
+            video_ids = query.get("v")
+            if video_ids and len(video_ids[0]) == 11:
+                return video_ids[0]
+    except Exception as e:
+        logger.warning(f"Error parsing URL query parameters: {e}")
+
+    return None
+
+
+def validate_youtube_url(url: str) -> bool:
+    """Validate if URL is a proper YouTube URL."""
+    video_id = get_youtube_video_id(url)
+    return video_id is not None

--- a/backend/src/api/routes/tasks/clips.py
+++ b/backend/src/api/routes/tasks/clips.py
@@ -1,0 +1,176 @@
+"""Clip editing endpoints: trim, split, merge, captions, regenerate, delete."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ....database import get_db
+from ....services.task_service import TaskService
+from ._helpers import _get_user_id_from_headers, _require_task_owner
+from .schemas import (
+    ClipCaptionsRequest,
+    ClipMergeRequest,
+    ClipRegenerateRequest,
+    ClipSplitRequest,
+    ClipTrimRequest,
+)
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.delete("/{task_id}/clips/{clip_id}")
+async def delete_clip(
+    task_id: str, clip_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Delete a specific clip."""
+    try:
+        user_id = _get_user_id_from_headers(request)
+        task_service = TaskService(db)
+
+        task = await task_service.task_repo.get_task_by_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        if task["user_id"] != user_id:
+            raise HTTPException(
+                status_code=403, detail="Not authorized to delete this clip"
+            )
+
+        await task_service.clip_repo.delete_clip(db, clip_id)
+        return {"message": "Clip deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting clip: {e}")
+        raise HTTPException(status_code=500, detail=f"Error deleting clip: {str(e)}")
+
+
+@router.patch("/{task_id}/clips/{clip_id}")
+async def trim_clip(
+    task_id: str,
+    clip_id: str,
+    body: ClipTrimRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Trim clip boundaries and regenerate clip file."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        updated_clip = await task_service.trim_clip(
+            task_id, clip_id, body.start_offset, body.end_offset
+        )
+        return {"clip": updated_clip}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error trimming clip: {e}")
+        raise HTTPException(status_code=500, detail=f"Error trimming clip: {str(e)}")
+
+
+@router.post("/{task_id}/clips/{clip_id}/split")
+async def split_clip(
+    task_id: str,
+    clip_id: str,
+    body: ClipSplitRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Split a clip into two clips."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        result = await task_service.split_clip(task_id, clip_id, body.split_time)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error splitting clip: {e}")
+        raise HTTPException(status_code=500, detail=f"Error splitting clip: {str(e)}")
+
+
+@router.post("/{task_id}/clips/merge")
+async def merge_clips(
+    task_id: str,
+    body: ClipMergeRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Merge multiple clips into one clip."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        result = await task_service.merge_clips(task_id, body.clip_ids)
+        return result
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error merging clips: {e}")
+        raise HTTPException(status_code=500, detail=f"Error merging clips: {str(e)}")
+
+
+@router.patch("/{task_id}/clips/{clip_id}/captions")
+async def update_clip_captions(
+    task_id: str,
+    clip_id: str,
+    body: ClipCaptionsRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Update clip caption text, timing style and highlighted words."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        updated_clip = await task_service.update_clip_captions(
+            task_id,
+            clip_id,
+            body.caption_text.strip(),
+            body.position,
+            body.highlight_words,
+        )
+        return {"clip": updated_clip}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating captions: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Error updating captions: {str(e)}"
+        )
+
+
+@router.post("/{task_id}/clips/{clip_id}/regenerate")
+async def regenerate_clip(
+    task_id: str,
+    clip_id: str,
+    body: ClipRegenerateRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Regenerate a single clip after editing timing values."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        updated_clip = await task_service.trim_clip(
+            task_id, clip_id, body.start_offset, body.end_offset
+        )
+        return {"clip": updated_clip, "message": "Clip regenerated successfully"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error regenerating clip: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Error regenerating clip: {str(e)}"
+        )

--- a/backend/src/api/routes/tasks/lifecycle.py
+++ b/backend/src/api/routes/tasks/lifecycle.py
@@ -1,0 +1,506 @@
+"""Task lifecycle endpoints: create, read, update, delete, progress, cancel, resume."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import redis.asyncio as redis
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+from sse_starlette.sse import EventSourceResponse
+
+from ....auth_headers import USER_ID_HEADER, get_signed_user_id
+from ....config import get_config
+from ....database import AsyncSessionLocal, get_db
+from ....font_registry import is_font_accessible
+from ....services.billing_service import BillingLimitExceeded, BillingService
+from ....services.task_service import TaskService
+from ....workers.job_queue import JobQueue
+from ....workers.progress import ProgressTracker
+from ._helpers import (
+    _get_user_id_from_headers,
+    _require_task_owner,
+)
+from .schemas import CreateTaskRequest, TaskSettingsRequest
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+@router.get("/")
+async def list_tasks(
+    request: Request, db: AsyncSession = Depends(get_db), limit: int = 50
+):
+    """Get all tasks for the authenticated user."""
+    user_id = _get_user_id_from_headers(request)
+
+    try:
+        task_service = TaskService(db)
+        tasks = await task_service.get_user_tasks(user_id, limit)
+        return {"tasks": tasks, "total": len(tasks)}
+    except Exception as e:
+        logger.error(f"Error retrieving user tasks: {e}")
+        raise HTTPException(status_code=500, detail=f"Error retrieving tasks: {str(e)}")
+
+
+@router.post("/")
+async def create_task(
+    body: CreateTaskRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new task and enqueue it for processing; returns task_id immediately."""
+    config = get_config()
+    if config.monetization_enabled:
+        user_id = get_signed_user_id(request, config)
+    else:
+        user_id = request.headers.get("user_id") or request.headers.get(USER_ID_HEADER)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="User authentication required")
+
+    raw_source = {"url": body.source.url, "title": body.source.title}
+    font_family = body.font_options.font_family
+    font_size = body.font_options.font_size
+    font_color = body.font_options.font_color
+    stroke_color = body.font_options.stroke_color
+    stroke_width = body.font_options.stroke_width
+    subtitle_bold = body.font_options.bold
+    subtitle_italic = body.font_options.italic
+    subtitle_underline = body.font_options.underline
+    caption_template = body.caption_template
+    include_broll = body.include_broll
+    processing_mode = body.processing_mode or config.default_processing_mode
+    output_format = body.output_format
+    add_subtitles = body.add_subtitles
+    # CapCut edit mode ships the clip into CapCut with an editable text track;
+    # burning subtitles or B-roll into the mp4 would defeat the purpose.
+    if output_format == "capcut":
+        add_subtitles = False
+        include_broll = False
+    avoid_original_subtitle = body.avoid_original_subtitle
+
+    try:
+        billing_service = BillingService(db)
+        await billing_service.assert_can_create_task(user_id)
+
+        task_service = TaskService(db)
+
+        task_id = await task_service.create_task_with_source(
+            user_id=user_id,
+            url=raw_source["url"],
+            title=raw_source.get("title"),
+            font_family=font_family,
+            font_size=font_size,
+            font_color=font_color,
+            caption_template=caption_template,
+            include_broll=include_broll,
+            processing_mode=processing_mode,
+            stroke_color=stroke_color,
+            stroke_width=stroke_width,
+            subtitle_bold=subtitle_bold,
+            subtitle_italic=subtitle_italic,
+            subtitle_underline=subtitle_underline,
+        )
+
+        source_type = task_service.video_service.determine_source_type(
+            raw_source["url"]
+        )
+
+        queue_adapter = getattr(request.app.state, "queue_adapter", JobQueue)
+        job_id = await queue_adapter.enqueue_processing_job(
+            "process_video_task",
+            processing_mode,
+            task_id,
+            raw_source["url"],
+            source_type,
+            user_id,
+            font_family,
+            font_size,
+            font_color,
+            caption_template,
+            processing_mode,
+            output_format,
+            add_subtitles,
+            stroke_color=stroke_color,
+            stroke_width=stroke_width,
+            bold=subtitle_bold,
+            italic=subtitle_italic,
+            underline=subtitle_underline,
+            avoid_original_subtitle=avoid_original_subtitle,
+        )
+
+        redis_client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password,
+            decode_responses=True,
+        )
+        try:
+            await redis_client.set(
+                f"task_source:{task_id}",
+                json.dumps(
+                    {
+                        "url": raw_source["url"],
+                        "source_type": source_type,
+                        "output_format": output_format,
+                        "add_subtitles": add_subtitles,
+                        "avoid_original_subtitle": avoid_original_subtitle,
+                    }
+                ),
+                ex=60 * 60 * 24 * 7,
+            )
+        finally:
+            await redis_client.close()
+
+        logger.info(f"Task {task_id} created and job {job_id} enqueued")
+
+        return {
+            "task_id": task_id,
+            "job_id": job_id,
+            "message": "Task created and queued for processing",
+        }
+
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except BillingLimitExceeded as e:
+        raise HTTPException(
+            status_code=402,
+            detail={
+                "code": "SUBSCRIPTION_REQUIRED",
+                "message": "Active subscription required to create tasks.",
+                "billing": e.summary,
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error creating task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error creating task: {str(e)}")
+
+
+@router.get("/{task_id}")
+async def get_task(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Get task details."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        task = await task_service.get_task_with_clips(task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return task
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error retrieving task: {str(e)}")
+
+
+@router.get("/{task_id}/clips")
+async def get_task_clips(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Get all clips for a task."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        task = await task_service.get_task_with_clips(task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        return {
+            "task_id": task_id,
+            "clips": task.get("clips", []),
+            "total_clips": len(task.get("clips", [])),
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error retrieving clips: {e}")
+        raise HTTPException(status_code=500, detail=f"Error retrieving clips: {str(e)}")
+
+
+@router.get("/{task_id}/progress")
+async def get_task_progress_sse(task_id: str, request: Request):
+    """SSE stream of real-time progress updates."""
+    user_id = _get_user_id_from_headers(request)
+
+    async with AsyncSessionLocal() as local_db:
+        task_service = TaskService(local_db)
+        task = await task_service.task_repo.get_task_by_id(local_db, task_id)
+
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    if task.get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="Not authorized for this task")
+
+    async def event_generator():
+        yield {
+            "event": "status",
+            "data": json.dumps(
+                {
+                    "task_id": task_id,
+                    "status": task.get("status"),
+                    "progress": task.get("progress", 0),
+                    "message": task.get("progress_message", ""),
+                }
+            ),
+        }
+
+        if task.get("status") in ["completed", "error"]:
+            yield {"event": "close", "data": json.dumps({"status": task.get("status")})}
+            return
+
+        runtime_config = get_config()
+        redis_client = redis.Redis(
+            host=runtime_config.redis_host,
+            port=runtime_config.redis_port,
+            password=runtime_config.redis_password,
+            decode_responses=True,
+        )
+
+        try:
+            async for progress_data in ProgressTracker.subscribe_to_progress(
+                redis_client, task_id
+            ):
+                event_type = progress_data.get("event_type", "progress")
+                yield {"event": event_type, "data": json.dumps(progress_data)}
+
+                if progress_data.get("status") in ["completed", "error"]:
+                    yield {
+                        "event": "close",
+                        "data": json.dumps({"status": progress_data.get("status")}),
+                    }
+                    break
+        finally:
+            await redis_client.close()
+
+    return EventSourceResponse(event_generator())
+
+
+@router.patch("/{task_id}")
+async def update_task(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Update task title."""
+    try:
+        data = await request.json()
+        title = data.get("title")
+        if not title:
+            raise HTTPException(status_code=400, detail="Title is required")
+
+        task_service = TaskService(db)
+        task = await _require_task_owner(request, task_service, db, task_id)
+        await task_service.source_repo.update_source_title(db, task["source_id"], title)
+        return {"message": "Task updated successfully", "task_id": task_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error updating task: {str(e)}")
+
+
+@router.delete("/{task_id}")
+async def delete_task(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Delete a task and all its associated clips."""
+    try:
+        user_id = _get_user_id_from_headers(request)
+        task_service = TaskService(db)
+        task = await task_service.task_repo.get_task_by_id(db, task_id)
+        if not task:
+            raise HTTPException(status_code=404, detail="Task not found")
+        if task["user_id"] != user_id:
+            raise HTTPException(
+                status_code=403, detail="Not authorized to delete this task"
+            )
+
+        await task_service.delete_task(task_id)
+        return {"message": "Task deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error deleting task: {str(e)}")
+
+
+@router.post("/{task_id}/settings")
+async def apply_task_settings(
+    task_id: str,
+    body: TaskSettingsRequest,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Update task-level styling settings and optionally apply to all existing clips."""
+    try:
+        task_service = TaskService(db)
+        await _require_task_owner(request, task_service, db, task_id)
+        task_record = await task_service.task_repo.get_task_by_id(db, task_id)
+        if not task_record:
+            raise HTTPException(status_code=404, detail="Task not found")
+        if not is_font_accessible(body.font_family, task_record["user_id"]):
+            raise HTTPException(
+                status_code=400, detail="Selected font is not available"
+            )
+        task = await task_service.update_task_settings(
+            task_id,
+            body.font_family,
+            body.font_size,
+            body.font_color,
+            body.caption_template,
+            body.include_broll,
+            body.apply_to_existing,
+        )
+        return {"task": task, "message": "Task settings updated"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating task settings: {e}")
+        raise HTTPException(
+            status_code=500, detail=f"Error updating task settings: {str(e)}"
+        )
+
+
+@router.post("/{task_id}/cancel")
+async def cancel_task(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Cancel an active queued or processing task."""
+    try:
+        config = get_config()
+        task_service = TaskService(db)
+        task = await _require_task_owner(request, task_service, db, task_id)
+
+        if task.get("status") in ["completed", "error", "cancelled"]:
+            return {"message": f"Task already in terminal state: {task.get('status')}"}
+
+        redis_client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password,
+            decode_responses=True,
+        )
+        try:
+            await redis_client.setex(f"task_cancel:{task_id}", 3600, "1")
+        finally:
+            await redis_client.close()
+
+        await task_service.task_repo.update_task_status(
+            db,
+            task_id,
+            "cancelled",
+            progress=0,
+            progress_message="Cancelled by user",
+        )
+
+        return {"message": "Task cancellation requested"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error cancelling task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error cancelling task: {str(e)}")
+
+
+@router.post("/{task_id}/resume")
+async def resume_task(
+    task_id: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Resume a cancelled or errored task by enqueueing a new worker job."""
+    try:
+        config = get_config()
+        task_service = TaskService(db)
+        task = await _require_task_owner(request, task_service, db, task_id)
+
+        if task.get("status") not in ["cancelled", "error", "queued"]:
+            raise HTTPException(
+                status_code=400,
+                detail="Only cancelled/error/queued tasks can be resumed",
+            )
+
+        source_url = task.get("source_url")
+        source_type = task.get("source_type")
+        output_format = "vertical"
+        avoid_original_subtitle = "none"
+        add_subtitles = True
+
+        redis_client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password,
+            decode_responses=True,
+        )
+        try:
+            source_payload = await redis_client.get(f"task_source:{task_id}")
+            if source_payload:
+                parsed = json.loads(source_payload)
+                if not source_url:
+                    source_url = parsed.get("url")
+                if not source_type:
+                    source_type = parsed.get("source_type")
+                of = parsed.get("output_format", output_format)
+                if of in ("vertical", "fit", "original", "capcut"):
+                    output_format = of
+                asub = parsed.get("add_subtitles", add_subtitles)
+                if isinstance(asub, bool):
+                    add_subtitles = asub
+                aos = parsed.get("avoid_original_subtitle", avoid_original_subtitle)
+                if aos in ("none", "bottom", "top"):
+                    avoid_original_subtitle = aos
+        finally:
+            await redis_client.close()
+
+        # Mirror the create-path enforcement: capcut mode must never burn in
+        # subtitles/B-roll, those land as editable tracks instead.
+        if output_format == "capcut":
+            add_subtitles = False
+
+        if not source_url or not source_type:
+            raise HTTPException(status_code=400, detail="Task source URL is missing")
+
+        redis_client = redis.Redis(
+            host=config.redis_host,
+            port=config.redis_port,
+            password=config.redis_password,
+            decode_responses=True,
+        )
+        try:
+            await redis_client.delete(f"task_cancel:{task_id}")
+        finally:
+            await redis_client.close()
+
+        await task_service.task_repo.update_task_status(
+            db,
+            task_id,
+            "queued",
+            progress=0,
+            progress_message="Re-queued by user",
+        )
+
+        processing_mode = task.get("processing_mode") or config.default_processing_mode
+
+        job_id = await JobQueue.enqueue_processing_job(
+            "process_video_task",
+            processing_mode,
+            task_id,
+            source_url,
+            source_type,
+            task["user_id"],
+            task.get("font_family") or "TikTokSans-Regular",
+            task.get("font_size") or 24,
+            task.get("font_color") or "#FFFFFF",
+            task.get("caption_template") or "default",
+            processing_mode,
+            output_format,
+            add_subtitles,
+            avoid_original_subtitle=avoid_original_subtitle,
+        )
+
+        return {"message": "Task resumed", "job_id": job_id}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error resuming task: {e}")
+        raise HTTPException(status_code=500, detail=f"Error resuming task: {str(e)}")

--- a/backend/src/api/routes/tasks/schemas.py
+++ b/backend/src/api/routes/tasks/schemas.py
@@ -1,0 +1,58 @@
+"""Pydantic request schemas for the ``/tasks/{id}/clips/*`` endpoints.
+
+These are a thin validation layer — they replace the hand-rolled
+``payload = await request.json()`` parsing that previously lived inline in
+each route, so FastAPI/Pydantic returns a structured 422 response on bad
+input instead of the routes reaching the service layer with silently
+coerced values.
+"""
+
+from __future__ import annotations
+
+from typing import List, Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ClipTrimRequest(BaseModel):
+    """Input for ``PATCH /tasks/{task_id}/clips/{clip_id}``."""
+
+    start_offset: float = Field(0.0, ge=0, description="Seconds to trim from the start")
+    end_offset: float = Field(0.0, ge=0, description="Seconds to trim from the end")
+
+
+class ClipSplitRequest(BaseModel):
+    """Input for ``POST /tasks/{task_id}/clips/{clip_id}/split``."""
+
+    split_time: float = Field(..., gt=0, description="Seconds into the clip")
+
+
+class ClipMergeRequest(BaseModel):
+    """Input for ``POST /tasks/{task_id}/clips/merge``."""
+
+    clip_ids: List[str] = Field(..., min_length=2)
+
+    @field_validator("clip_ids")
+    @classmethod
+    def _reject_blank_ids(cls, v: List[str]) -> List[str]:
+        cleaned = [item.strip() for item in v]
+        if any(not item for item in cleaned):
+            raise ValueError("clip_ids entries must be non-empty strings")
+        return cleaned
+
+
+class ClipCaptionsRequest(BaseModel):
+    """Input for ``PATCH /tasks/{task_id}/clips/{clip_id}/captions``."""
+
+    caption_text: str = Field("", max_length=8000)
+    position: Literal["top", "center", "bottom"] = "bottom"
+    highlight_words: List[str] = Field(default_factory=list)
+
+    @field_validator("highlight_words")
+    @classmethod
+    def _clean_highlight_words(cls, v: List[str]) -> List[str]:
+        return [str(item) for item in v if str(item).strip()]
+
+
+class ClipRegenerateRequest(ClipTrimRequest):
+    """Same shape as trim; kept distinct for route clarity."""

--- a/backend/src/api/routes/tasks/schemas.py
+++ b/backend/src/api/routes/tasks/schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic request schemas for the ``/tasks/{id}/clips/*`` endpoints.
+"""Pydantic request schemas for the ``/tasks/*`` and ``/tasks/{id}/clips/*`` endpoints.
 
 These are a thin validation layer — they replace the hand-rolled
 ``payload = await request.json()`` parsing that previously lived inline in
@@ -9,9 +9,9 @@ coerced values.
 
 from __future__ import annotations
 
-from typing import List, Literal
+from typing import List, Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class ClipTrimRequest(BaseModel):
@@ -56,3 +56,61 @@ class ClipCaptionsRequest(BaseModel):
 
 class ClipRegenerateRequest(ClipTrimRequest):
     """Same shape as trim; kept distinct for route clarity."""
+
+
+# ---------------------------------------------------------------------------
+# Task lifecycle schemas
+# ---------------------------------------------------------------------------
+
+
+HEX_COLOR_PATTERN = r"^#[0-9A-Fa-f]{6}$"
+
+
+class SourceInput(BaseModel):
+    """Input source for a new task (YouTube URL or uploaded video reference)."""
+
+    url: str = Field(..., min_length=1, max_length=2048)
+    title: Optional[str] = Field(None, max_length=500)
+
+
+class FontOptions(BaseModel):
+    """Styling options for subtitles on a new task."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    font_family: str = Field("TikTokSans-Regular", min_length=1, max_length=120)
+    font_size: int = Field(24, ge=12, le=72)
+    font_color: str = Field("#FFFFFF", pattern=HEX_COLOR_PATTERN)
+    stroke_color: Optional[str] = Field(None, pattern=HEX_COLOR_PATTERN)
+    stroke_width: Optional[int] = Field(None, ge=0, le=12)
+    bold: bool = False
+    italic: bool = False
+    underline: bool = False
+
+
+class CreateTaskRequest(BaseModel):
+    """Input for ``POST /tasks/``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    source: SourceInput
+    font_options: FontOptions = Field(default_factory=FontOptions)
+    caption_template: str = Field("default", min_length=1, max_length=64)
+    include_broll: bool = False
+    processing_mode: Optional[Literal["fast", "balanced", "quality"]] = None
+    output_format: Literal["vertical", "fit", "original", "capcut"] = "vertical"
+    add_subtitles: bool = True
+    avoid_original_subtitle: Literal["none", "bottom", "top"] = "none"
+
+
+class TaskSettingsRequest(BaseModel):
+    """Input for ``POST /tasks/{task_id}/settings``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    font_family: str = Field("TikTokSans-Regular", min_length=1, max_length=120)
+    font_size: int = Field(24, ge=12, le=72)
+    font_color: str = Field("#FFFFFF", pattern=HEX_COLOR_PATTERN)
+    caption_template: str = Field("default", min_length=1, max_length=64)
+    include_broll: bool = False
+    apply_to_existing: bool = False

--- a/backend/src/font_registry.py
+++ b/backend/src/font_registry.py
@@ -1,14 +1,122 @@
+from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 SUPPORTED_FONT_EXTENSIONS = (".ttf", ".otf")
 FONTS_DIR = Path(__file__).parent.parent / "fonts"
 USER_FONTS_DIR = FONTS_DIR / "users"
 
+# Fallback chain used when the user-selected font does not cover the actual
+# subtitle text (e.g., TikTok Sans selected but transcript contains Hangul).
+# Earlier entries win when both cover the text. Pretendard is first because
+# it has excellent Korean + Latin coverage in one file.
+_FALLBACK_CHAIN: tuple[str, ...] = (
+    "Pretendard-Variable",
+    "NotoSansKR-Variable",
+    "BlackHanSans-Regular",
+    "GowunDodum-Regular",
+)
+
+# Known font metadata — display name in Korean + language classification.
+# Match on lowercased stem. Stems not listed fall back to auto-generated display names.
+_FONT_META: dict[str, dict[str, str]] = {
+    # Korean fonts
+    "pretendard-variable": {"display_name": "프리텐다드", "language": "korean"},
+    "notosanskr-variable": {"display_name": "노토 산스 KR", "language": "korean"},
+    "blackhansans-regular": {"display_name": "검은고딕 (Black Han Sans)", "language": "korean"},
+    "gowundodum-regular": {"display_name": "고운도담", "language": "korean"},
+    # Latin fonts
+    "tiktoksans-regular": {"display_name": "TikTok Sans", "language": "latin"},
+    "inter": {"display_name": "Inter", "language": "latin"},
+    "roboto": {"display_name": "Roboto", "language": "latin"},
+    "opensans": {"display_name": "Open Sans", "language": "latin"},
+    "dmsans": {"display_name": "DM Sans", "language": "latin"},
+    "poppins-extrabold": {"display_name": "Poppins ExtraBold", "language": "latin"},
+    "montserrat-variable-wght": {"display_name": "Montserrat", "language": "latin"},
+    "oswald-variable-wght": {"display_name": "Oswald", "language": "latin"},
+    "raleway-variable-wght": {"display_name": "Raleway", "language": "latin"},
+    "worksans": {"display_name": "Work Sans", "language": "latin"},
+    "nunitosans": {"display_name": "Nunito Sans", "language": "latin"},
+    "urbanist": {"display_name": "Urbanist", "language": "latin"},
+    "rubik": {"display_name": "Rubik", "language": "latin"},
+    "sora": {"display_name": "Sora", "language": "latin"},
+    "leaguespartan": {"display_name": "League Spartan", "language": "latin"},
+    "anton-regular": {"display_name": "Anton", "language": "latin"},
+    "archivoblack-regular": {"display_name": "Archivo Black", "language": "latin"},
+    "bangers-regular": {"display_name": "Bangers", "language": "latin"},
+    "barlowcondensed-bold": {"display_name": "Barlow Condensed Bold", "language": "latin"},
+    "bebasneue-regular": {"display_name": "Bebas Neue", "language": "latin"},
+    "theboldfont": {"display_name": "The Bold Font", "language": "latin"},
+}
+
 
 def _display_name(font_stem: str) -> str:
     return font_stem.replace("-", " ").replace("_", " ").strip().title()
+
+
+# Common filename patterns for bold / italic variants.
+_BOLD_TOKENS = ("-bold", "-bd", "_bold", "bold")
+_ITALIC_TOKENS = ("-italic", "-it", "_italic", "italic", "-oblique")
+
+
+def _has_variant(font_path: Path, tokens: tuple[str, ...]) -> Path | None:
+    """Look for a sibling font file whose stem is the requested variant."""
+    stem = font_path.stem
+    # Try adding a suffix like "-Bold" to the current stem
+    for token in tokens:
+        for candidate_stem in (stem + token, stem + token.replace("-", "")):
+            for extension in SUPPORTED_FONT_EXTENSIONS:
+                candidate = font_path.parent / f"{candidate_stem}{extension}"
+                if candidate.exists():
+                    return candidate
+    # Try replacing common weight tokens in the existing stem (e.g., "-Regular" -> "-Bold")
+    lowered = stem.lower()
+    for replacement in ("regular", "light", "medium", "book", "roman"):
+        if replacement in lowered:
+            for token in ("Bold",) if tokens is _BOLD_TOKENS else ("Italic", "Oblique"):
+                replaced = re.sub(replacement, token, stem, flags=re.IGNORECASE)
+                for extension in SUPPORTED_FONT_EXTENSIONS:
+                    candidate = font_path.parent / f"{replaced}{extension}"
+                    if candidate.exists() and candidate != font_path:
+                        return candidate
+    return None
+
+
+def detect_variants(font_path: Path) -> dict[str, str | None]:
+    """Return paths to bold and italic variants for a given font, if present."""
+    return {
+        "bold_path": str(_has_variant(font_path, _BOLD_TOKENS) or "") or None,
+        "italic_path": str(_has_variant(font_path, _ITALIC_TOKENS) or "") or None,
+    }
+
+
+# Fonts known to have a usable single-file "variable" axis for weight.
+# Frontend can still apply a weight preference via Pillow if the environment
+# supports it — this flag is informational.
+_VARIABLE_FONTS = (
+    "pretendard-variable",
+    "notosanskr-variable",
+    "montserrat-variable-wght",
+    "oswald-variable-wght",
+    "raleway-variable-wght",
+)
+
+
+def _lookup_meta(font_stem: str) -> dict[str, str]:
+    key = font_stem.lower()
+    meta = _FONT_META.get(key)
+    if meta:
+        return meta
+    # Heuristic: detect Korean-capable fonts by substring
+    lowered = key
+    korean_hints = ("kr", "korean", "hangul", "hansans", "gowun", "pretendard", "nanum", "jeju", "noto")
+    if any(hint in lowered for hint in korean_hints):
+        return {"display_name": _display_name(font_stem), "language": "korean"}
+    return {"display_name": _display_name(font_stem), "language": "latin"}
 
 
 def sanitize_user_id_for_path(user_id: str) -> str:
@@ -25,18 +133,54 @@ def _collect_fonts_from_dir(font_dir: Path, scope: str) -> list[dict[str, Any]]:
         return []
 
     fonts: list[dict[str, Any]] = []
+    # We need to track the stems of variant files (e.g. "Inter-Bold") so we
+    # don't also list them as separate top-level fonts.
+    variant_stems: set[str] = set()
+
+    candidates: list[Path] = []
     for extension in SUPPORTED_FONT_EXTENSIONS:
-        for font_path in sorted(font_dir.glob(f"*{extension}")):
-            fonts.append(
-                {
-                    "name": font_path.stem,
-                    "display_name": _display_name(font_path.stem),
-                    "filename": font_path.name,
-                    "format": extension.lstrip("."),
-                    "file_path": str(font_path),
-                    "scope": scope,
-                }
+        candidates.extend(sorted(font_dir.glob(f"*{extension}")))
+
+    # First pass: collect variant paths so we know which stems are "secondary"
+    primary_fonts: list[Path] = []
+    for font_path in candidates:
+        stem_lower = font_path.stem.lower()
+        is_variant = any(tok.strip("-_") in stem_lower for tok in (*_BOLD_TOKENS, *_ITALIC_TOKENS))
+        # Keep "Regular" / "Variable" / anything-not-bold-or-italic as primary.
+        is_plain_bold_only = stem_lower.endswith("bold") or stem_lower.endswith("-bold")
+        is_plain_italic_only = stem_lower.endswith("italic") or stem_lower.endswith("-italic")
+        if is_variant and (is_plain_bold_only or is_plain_italic_only):
+            # Does a non-variant sibling exist? If so, hide this as primary.
+            base_stem = re.sub(r"[-_]?(bold|italic|oblique|bd|it)$", "", font_path.stem, flags=re.IGNORECASE)
+            has_sibling = any(
+                (font_path.parent / f"{base_stem}{ext}").exists()
+                or (font_path.parent / f"{base_stem}-Regular{ext}").exists()
+                for ext in SUPPORTED_FONT_EXTENSIONS
             )
+            if has_sibling:
+                variant_stems.add(font_path.stem)
+                continue
+        primary_fonts.append(font_path)
+
+    for font_path in primary_fonts:
+        meta = _lookup_meta(font_path.stem)
+        variants = detect_variants(font_path)
+        stem_lower = font_path.stem.lower()
+        is_variable = stem_lower in _VARIABLE_FONTS or "variable" in stem_lower
+        fonts.append(
+            {
+                "name": font_path.stem,
+                "display_name": meta["display_name"],
+                "language": meta["language"],
+                "filename": font_path.name,
+                "format": font_path.suffix.lstrip("."),
+                "file_path": str(font_path),
+                "scope": scope,
+                "has_bold_variant": variants["bold_path"] is not None,
+                "has_italic_variant": variants["italic_path"] is not None,
+                "is_variable": is_variable,
+            }
+        )
 
     return fonts
 
@@ -47,7 +191,30 @@ def get_available_fonts(user_id: str | None = None) -> list[dict[str, Any]]:
     if user_id:
         fonts.extend(_collect_fonts_from_dir(get_user_fonts_dir(user_id), scope="user"))
 
-    return sorted(fonts, key=lambda font: font["display_name"])
+    # Korean fonts first, then by display name
+    return sorted(
+        fonts,
+        key=lambda font: (0 if font.get("language") == "korean" else 1, font["display_name"]),
+    )
+
+
+def _is_path_inside(candidate: Path, base: Path) -> bool:
+    """True if ``candidate`` resolves to a location under ``base``.
+
+    Protects against path-traversal tricks like ``../../etc/passwd`` by
+    resolving both sides and checking for a proper prefix on the resolved
+    paths. Does not require ``candidate`` to exist.
+    """
+    try:
+        resolved_candidate = candidate.resolve(strict=False)
+        resolved_base = base.resolve(strict=False)
+    except (OSError, RuntimeError):
+        return False
+    try:
+        resolved_candidate.relative_to(resolved_base)
+        return True
+    except ValueError:
+        return False
 
 
 def find_font_path(
@@ -59,6 +226,11 @@ def find_font_path(
     if not requested:
         return None
 
+    # Reject obvious traversal payloads before any filesystem I/O — belt &
+    # braces alongside the ``_is_path_inside`` resolve check below.
+    if any(sep in requested for sep in ("..", "/", "\\", "\x00")):
+        return None
+
     search_dirs = [FONTS_DIR]
     if user_id:
         search_dirs.insert(0, get_user_fonts_dir(user_id))
@@ -68,12 +240,13 @@ def find_font_path(
         if (
             exact_file.exists()
             and exact_file.suffix.lower() in SUPPORTED_FONT_EXTENSIONS
+            and _is_path_inside(exact_file, search_dir)
         ):
             return exact_file
 
         for extension in SUPPORTED_FONT_EXTENSIONS:
             candidate = search_dir / f"{requested}{extension}"
-            if candidate.exists():
+            if candidate.exists() and _is_path_inside(candidate, search_dir):
                 return candidate
 
     normalized_requested = re.sub(r"[^a-z0-9]", "", requested.lower())
@@ -84,7 +257,10 @@ def find_font_path(
 
     if allow_all_user_fonts:
         for font_path in USER_FONTS_DIR.glob(f"**/{requested}.*"):
-            if font_path.suffix.lower() in SUPPORTED_FONT_EXTENSIONS:
+            if (
+                font_path.suffix.lower() in SUPPORTED_FONT_EXTENSIONS
+                and _is_path_inside(font_path, USER_FONTS_DIR)
+            ):
                 return font_path
 
     return None
@@ -106,3 +282,87 @@ def build_user_font_stem(user_id: str, original_stem: str) -> str:
 
 def is_font_accessible(font_name: str, user_id: str) -> bool:
     return find_font_path(font_name, user_id=user_id) is not None
+
+
+@lru_cache(maxsize=64)
+def _font_codepoints(font_path_str: str) -> frozenset[int]:
+    """Return the set of Unicode codepoints a font file's cmap covers."""
+    try:
+        from fontTools.ttLib import TTFont
+    except ImportError:
+        logger.warning("fontTools not installed — cannot verify font coverage")
+        return frozenset()
+
+    try:
+        font = TTFont(font_path_str, fontNumber=0, ignoreDecompileErrors=True)
+    except Exception as exc:
+        logger.warning("Failed to read font %s for coverage check: %s", font_path_str, exc)
+        return frozenset()
+
+    covered: set[int] = set()
+    try:
+        for cmap in font["cmap"].tables:
+            covered.update(cmap.cmap.keys())
+    except Exception as exc:
+        logger.warning("Failed to parse cmap for %s: %s", font_path_str, exc)
+    finally:
+        try:
+            font.close()
+        except Exception:
+            pass
+    return frozenset(covered)
+
+
+def font_covers_text(font_path: Path, text: str) -> bool:
+    """True if the font covers every non-whitespace character in ``text``."""
+    if not text:
+        return True
+    covered = _font_codepoints(str(font_path))
+    if not covered:
+        # Unknown coverage — treat as "covers" to avoid false fallback when
+        # fontTools is unavailable. Better to render with the requested font
+        # and let the result show the issue than to silently swap.
+        return True
+    for ch in text:
+        if ch.isspace():
+            continue
+        if ord(ch) not in covered:
+            return False
+    return True
+
+
+def _iter_fallback_candidates(user_id: str | None) -> Iterable[Path]:
+    for name in _FALLBACK_CHAIN:
+        candidate = find_font_path(name, user_id=user_id, allow_all_user_fonts=True)
+        if candidate:
+            yield candidate
+
+
+def select_font_for_text(
+    preferred_font_name: str,
+    text: str,
+    user_id: str | None = None,
+) -> tuple[str, Path | None]:
+    """
+    Return (font_name, font_path) best suited for rendering ``text``.
+
+    If the preferred font covers the text, it is returned unchanged. Otherwise
+    the first font from ``_FALLBACK_CHAIN`` that covers the text is returned.
+    If none cover (unlikely), the preferred font is returned and the caller
+    gets to decide how to handle missing glyphs.
+    """
+    preferred_path = find_font_path(preferred_font_name, user_id=user_id, allow_all_user_fonts=True)
+
+    if preferred_path and font_covers_text(preferred_path, text):
+        return preferred_font_name, preferred_path
+
+    for candidate_path in _iter_fallback_candidates(user_id):
+        if font_covers_text(candidate_path, text):
+            logger.info(
+                "Font '%s' lacks glyphs for subtitle text; falling back to '%s'",
+                preferred_font_name,
+                candidate_path.stem,
+            )
+            return candidate_path.stem, candidate_path
+
+    return preferred_font_name, preferred_path

--- a/backend/src/services/_task_helpers.py
+++ b/backend/src/services/_task_helpers.py
@@ -1,0 +1,39 @@
+"""Pure utility helpers extracted from ``TaskService`` for size hygiene."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+import hashlib
+
+
+def build_cache_key(url: str, source_type: str, processing_mode: str) -> str:
+    payload = f"{source_type}|{processing_mode}|{url.strip()}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def seconds_to_mmss(seconds: float) -> str:
+    total = max(0, int(round(seconds)))
+    minutes = total // 60
+    secs = total % 60
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def is_queued_task_stale(task: Dict[str, Any], timeout_seconds: int) -> bool:
+    """Detect queued tasks that have likely stalled due to worker issues."""
+    if task.get("status") != "queued":
+        return False
+
+    created_at = task.get("created_at")
+    updated_at = task.get("updated_at") or created_at
+
+    if not created_at or not updated_at:
+        return False
+
+    now = (
+        datetime.now(updated_at.tzinfo)
+        if getattr(updated_at, "tzinfo", None)
+        else datetime.utcnow()
+    )
+    age_seconds = (now - updated_at).total_seconds()
+    return age_seconds >= timeout_seconds

--- a/backend/src/services/_task_notification_mixin.py
+++ b/backend/src/services/_task_notification_mixin.py
@@ -1,0 +1,75 @@
+"""Task-completion email notification, extracted from ``TaskService``.
+
+The email symbols are resolved through the ``task_service`` module at call
+time so tests can continue to patch ``task_service.TaskCompletionEmailService``
+without seeing our import. ``self.db``, ``self.task_repo`` and ``self.config``
+come from ``TaskService.__init__``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class _TaskNotificationMixin:
+    async def _send_completion_notification_if_needed(
+        self, *, task_id: str, clips_count: int
+    ) -> None:
+        from . import task_service as _ts
+
+        context = await self.task_repo.get_task_notification_context(self.db, task_id)
+        if not context:
+            logger.warning("Task %s missing notification context; skipping email", task_id)
+            return
+
+        if not context.get("notify_on_completion"):
+            return
+
+        if context.get("completion_notification_sent_at"):
+            logger.info(
+                "Completion notification already sent for task %s; skipping", task_id
+            )
+            return
+
+        user_email = context.get("user_email")
+        if not user_email:
+            logger.warning(
+                "Task %s has notify_on_completion enabled but user email is missing",
+                task_id,
+            )
+            return
+
+        email_service = _ts.TaskCompletionEmailService(self.config)
+        if not email_service.is_configured:
+            logger.warning(
+                "Skipping completion notification for task %s because Resend is not configured",
+                task_id,
+            )
+            return
+
+        try:
+            await email_service.send_task_completed_email(
+                recipient=_ts.TaskCompletionRecipient(
+                    email=user_email,
+                    name=context.get("user_name"),
+                    first_name=context.get("user_first_name"),
+                ),
+                task_id=task_id,
+                source_title=context.get("source_title"),
+                clips_count=clips_count,
+            )
+            stamped = await self.task_repo.mark_completion_notification_sent(
+                self.db, task_id
+            )
+            if not stamped:
+                logger.info(
+                    "Completion notification stamp already existed for task %s",
+                    task_id,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to send completion notification for task %s",
+                task_id,
+            )

--- a/backend/src/services/task_service.py
+++ b/backend/src/services/task_service.py
@@ -8,7 +8,6 @@ import logging
 from datetime import datetime
 from pathlib import Path
 import json
-import hashlib
 from time import perf_counter
 
 import redis.asyncio as redis
@@ -17,25 +16,29 @@ from ..repositories.task_repository import TaskRepository
 from ..repositories.source_repository import SourceRepository
 from ..repositories.clip_repository import ClipRepository
 from ..repositories.cache_repository import CacheRepository
+from . import usage_service
+from ..usage_context import current_usage
 from .video_service import VideoService
-from .task_completion_email_service import (
+from .task_completion_email_service import (  # noqa: F401 — re-exported for tests to patch
     TaskCompletionEmailService,
     TaskCompletionRecipient,
 )
 from ..config import Config, get_config
-from ..clip_editor import (
-    trim_clip_file,
-    split_clip_file,
-    merge_clip_files,
-    overlay_custom_captions,
-)
-from ..video_utils import parse_timestamp_to_seconds
+from ._clip_edit_mixin import _ClipEditMixin
+from ._task_helpers import build_cache_key, is_queued_task_stale, seconds_to_mmss
+from ._task_notification_mixin import _TaskNotificationMixin
 
 logger = logging.getLogger(__name__)
 
 
-class TaskService:
-    """Service for task workflow orchestration."""
+class TaskService(_ClipEditMixin, _TaskNotificationMixin):
+    """Service for task workflow orchestration.
+
+    Clip-editing methods (``trim_clip``, ``split_clip``, ``merge_clips``,
+    ``update_clip_captions``, ``regenerate_all_clips_for_task``) live in
+    :class:`_ClipEditMixin`. Completion-email logic lives in
+    :class:`_TaskNotificationMixin`.
+    """
 
     def __init__(self, db: AsyncSession, config: Config | None = None):
         self.db = db
@@ -46,29 +49,10 @@ class TaskService:
         self.video_service = VideoService()
         self.config = config or get_config()
 
-    @staticmethod
-    def _build_cache_key(url: str, source_type: str, processing_mode: str) -> str:
-        payload = f"{source_type}|{processing_mode}|{url.strip()}"
-        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    _build_cache_key = staticmethod(build_cache_key)
 
     def _is_stale_queued_task(self, task: Dict[str, Any]) -> bool:
-        """Detect queued tasks that have likely stalled due to worker issues."""
-        if task.get("status") != "queued":
-            return False
-
-        created_at = task.get("created_at")
-        updated_at = task.get("updated_at") or created_at
-
-        if not created_at or not updated_at:
-            return False
-
-        now = (
-            datetime.now(updated_at.tzinfo)
-            if getattr(updated_at, "tzinfo", None)
-            else datetime.utcnow()
-        )
-        age_seconds = (now - updated_at).total_seconds()
-        return age_seconds >= self.config.queued_task_timeout_seconds
+        return is_queued_task_stale(task, self.config.queued_task_timeout_seconds)
 
     async def create_task_with_source(
         self,
@@ -81,6 +65,11 @@ class TaskService:
         caption_template: str = "default",
         include_broll: bool = False,
         processing_mode: str = "fast",
+        stroke_color: Optional[str] = None,
+        stroke_width: Optional[int] = None,
+        subtitle_bold: bool = False,
+        subtitle_italic: bool = False,
+        subtitle_underline: bool = False,
     ) -> str:
         """
         Create a new task with associated source.
@@ -117,6 +106,11 @@ class TaskService:
             caption_template=caption_template,
             include_broll=include_broll,
             processing_mode=processing_mode,
+            stroke_color=stroke_color,
+            stroke_width=stroke_width,
+            subtitle_bold=subtitle_bold,
+            subtitle_italic=subtitle_italic,
+            subtitle_underline=subtitle_underline,
         )
 
         logger.info(f"Created task {task_id} for user {user_id}")
@@ -137,11 +131,21 @@ class TaskService:
         progress_callback: Optional[Callable] = None,
         should_cancel: Optional[Callable] = None,
         clip_ready_callback: Optional[Callable] = None,
+        stroke_color: Optional[str] = None,
+        stroke_width: Optional[int] = None,
+        bold: bool = False,
+        italic: bool = False,
+        underline: bool = False,
+        avoid_original_subtitle: str = "none",
     ) -> Dict[str, Any]:
         """
         Process a task: download video, analyze, create clips.
         Returns processing results.
         """
+        # Start recording API usage for this task. The ContextVar lives for
+        # the duration of this call; low-level code (AssemblyAI, LLM) reads
+        # it and appends events without knowing about task_service.
+        recorder, recorder_token = usage_service.start_recording()
         try:
             logger.info(f"Starting processing for task {task_id}")
             started_at = datetime.utcnow()
@@ -204,6 +208,11 @@ class TaskService:
                 cached_analysis_json=cached_analysis_json,
                 progress_callback=update_progress,
                 should_cancel=should_cancel,
+                stroke_color=stroke_color,
+                stroke_width=stroke_width,
+                bold=bold,
+                italic=italic,
+                underline=underline,
             )
             stage_timings["pipeline_seconds"] = round(
                 perf_counter() - pipeline_start, 3
@@ -254,6 +263,12 @@ class TaskService:
                     caption_template,
                     output_format,
                     add_subtitles,
+                    stroke_color=stroke_color,
+                    stroke_width=stroke_width,
+                    bold=bold,
+                    italic=italic,
+                    underline=underline,
+                    avoid_original_subtitle=avoid_original_subtitle,
                 )
                 if clip_info is None:
                     continue  # Skip failed clip
@@ -364,64 +379,20 @@ class TaskService:
                 error_code=error_code,
             )
             raise
-
-    async def _send_completion_notification_if_needed(
-        self, *, task_id: str, clips_count: int
-    ) -> None:
-        context = await self.task_repo.get_task_notification_context(self.db, task_id)
-        if not context:
-            logger.warning("Task %s missing notification context; skipping email", task_id)
-            return
-
-        if not context.get("notify_on_completion"):
-            return
-
-        if context.get("completion_notification_sent_at"):
-            logger.info(
-                "Completion notification already sent for task %s; skipping", task_id
-            )
-            return
-
-        user_email = context.get("user_email")
-        if not user_email:
-            logger.warning(
-                "Task %s has notify_on_completion enabled but user email is missing",
-                task_id,
-            )
-            return
-
-        email_service = TaskCompletionEmailService(self.config)
-        if not email_service.is_configured:
-            logger.warning(
-                "Skipping completion notification for task %s because Resend is not configured",
-                task_id,
-            )
-            return
-
-        try:
-            await email_service.send_task_completed_email(
-                recipient=TaskCompletionRecipient(
-                    email=user_email,
-                    name=context.get("user_name"),
-                    first_name=context.get("user_first_name"),
-                ),
-                task_id=task_id,
-                source_title=context.get("source_title"),
-                clips_count=clips_count,
-            )
-            stamped = await self.task_repo.mark_completion_notification_sent(
-                self.db, task_id
-            )
-            if not stamped:
-                logger.info(
-                    "Completion notification stamp already existed for task %s",
-                    task_id,
+        finally:
+            current_usage.reset(recorder_token)
+            try:
+                task_row = await self.task_repo.get_task_by_id(self.db, task_id)
+                task_user_id = task_row.get("user_id") if task_row else None
+                await usage_service.persist_recorder(
+                    self.db, recorder, task_id, task_user_id
                 )
-        except Exception:
-            logger.exception(
-                "Failed to send completion notification for task %s",
-                task_id,
-            )
+            except Exception as persist_exc:
+                logger.warning(
+                    "Failed to persist API usage for task %s: %s",
+                    task_id,
+                    persist_exc,
+                )
 
     async def get_task_with_clips(self, task_id: str) -> Optional[Dict[str, Any]]:
         """Get task details with all clips."""
@@ -504,294 +475,8 @@ class TaskService:
 
         return await self.get_task_with_clips(task_id) or {}
 
-    async def regenerate_all_clips_for_task(
-        self,
-        task_id: str,
-        font_family: str,
-        font_size: int,
-        font_color: str,
-        caption_template: str,
-    ) -> None:
-        """Regenerate all clips in a task using existing segment boundaries."""
-        task = await self.task_repo.get_task_by_id(self.db, task_id)
-        if not task:
-            raise ValueError("Task not found")
-
-        source_url = task.get("source_url")
-        source_type = task.get("source_type")
-        output_format = "vertical"
-        add_subtitles = True
-
-        # Preserve original output_format and add_subtitles from task creation (stored in Redis)
-        redis_client = redis.Redis(
-            host=self.config.redis_host,
-            port=self.config.redis_port,
-            password=self.config.redis_password,
-            decode_responses=True,
-        )
-        try:
-            source_payload = await redis_client.get(f"task_source:{task_id}")
-            if source_payload:
-                parsed = json.loads(source_payload)
-                of = parsed.get("output_format", output_format)
-                if of in ("vertical", "original"):
-                    output_format = of
-                asub = parsed.get("add_subtitles", add_subtitles)
-                if isinstance(asub, bool):
-                    add_subtitles = asub
-        finally:
-            await redis_client.close()
-
-        if not source_url or not source_type:
-            raise ValueError("Task source URL is missing; cannot regenerate clips")
-
-        clips = await self.clip_repo.get_clips_by_task(self.db, task_id)
-        if not clips:
-            return
-
-        video_path: Path
-        if source_type == "youtube":
-            downloaded = await self.video_service.download_video(source_url)
-            if not downloaded:
-                raise ValueError("Failed to download source video for regeneration")
-            video_path = Path(downloaded)
-        else:
-            video_path = self.video_service.resolve_local_video_path(source_url)
-            if not video_path.exists():
-                raise ValueError("Source video file no longer exists")
-
-        segments = [
-            {
-                "start_time": clip["start_time"],
-                "end_time": clip["end_time"],
-                "text": clip.get("text") or "",
-                "relevance_score": clip.get("relevance_score", 0.5),
-                "reasoning": clip.get("reasoning")
-                or "Regenerated with updated settings",
-                "virality_score": clip.get("virality_score", 0),
-                "hook_score": clip.get("hook_score", 0),
-                "engagement_score": clip.get("engagement_score", 0),
-                "value_score": clip.get("value_score", 0),
-                "shareability_score": clip.get("shareability_score", 0),
-                "hook_type": clip.get("hook_type"),
-            }
-            for clip in clips
-        ]
-
-        clips_info = await self.video_service.create_video_clips(
-            video_path,
-            segments,
-            font_family,
-            font_size,
-            font_color,
-            caption_template,
-            output_format,
-            add_subtitles,
-        )
-
-        await self.clip_repo.delete_clips_by_task(self.db, task_id)
-
-        clip_ids = []
-        for i, clip_info in enumerate(clips_info):
-            clip_id = await self.clip_repo.create_clip(
-                self.db,
-                task_id=task_id,
-                filename=clip_info["filename"],
-                file_path=clip_info["path"],
-                start_time=clip_info["start_time"],
-                end_time=clip_info["end_time"],
-                duration=clip_info["duration"],
-                text=clip_info.get("text") or "",
-                relevance_score=clip_info.get("relevance_score", 0.5),
-                reasoning=clip_info.get("reasoning")
-                or "Regenerated with updated settings",
-                clip_order=i + 1,
-                virality_score=clip_info.get("virality_score", 0),
-                hook_score=clip_info.get("hook_score", 0),
-                engagement_score=clip_info.get("engagement_score", 0),
-                value_score=clip_info.get("value_score", 0),
-                shareability_score=clip_info.get("shareability_score", 0),
-                hook_type=clip_info.get("hook_type"),
-            )
-            clip_ids.append(clip_id)
-
-        await self.task_repo.update_task_clips(self.db, task_id, clip_ids)
-
-    async def trim_clip(
-        self,
-        task_id: str,
-        clip_id: str,
-        start_offset: float,
-        end_offset: float,
-    ) -> Dict[str, Any]:
-        clip = await self.clip_repo.get_clip_by_id(self.db, clip_id)
-        if not clip or clip["task_id"] != task_id:
-            raise ValueError("Clip not found")
-
-        input_path = Path(clip["file_path"])
-        if not input_path.exists():
-            raise ValueError("Clip file not found")
-
-        output_path = trim_clip_file(
-            input_path, Path(self.config.temp_dir) / "clips", start_offset, end_offset
-        )
-        clip_duration = max(0.1, clip["duration"] - start_offset - end_offset)
-
-        start_seconds = parse_timestamp_to_seconds(clip["start_time"]) + start_offset
-        end_seconds = start_seconds + clip_duration
-
-        new_start = self._seconds_to_mmss(start_seconds)
-        new_end = self._seconds_to_mmss(end_seconds)
-
-        await self.clip_repo.update_clip(
-            self.db,
-            clip_id,
-            output_path.name,
-            str(output_path),
-            new_start,
-            new_end,
-            clip_duration,
-            clip.get("text") or "",
-        )
-        return (await self.clip_repo.get_clip_by_id(self.db, clip_id)) or {}
-
-    async def split_clip(
-        self, task_id: str, clip_id: str, split_time: float
-    ) -> Dict[str, Any]:
-        clip = await self.clip_repo.get_clip_by_id(self.db, clip_id)
-        if not clip or clip["task_id"] != task_id:
-            raise ValueError("Clip not found")
-
-        input_path = Path(clip["file_path"])
-        if not input_path.exists():
-            raise ValueError("Clip file not found")
-
-        first_path, second_path = split_clip_file(
-            input_path, Path(self.config.temp_dir) / "clips", split_time
-        )
-
-        start_seconds = parse_timestamp_to_seconds(clip["start_time"])
-        clamped_split = max(0.2, min(split_time, float(clip["duration"]) - 0.2))
-        split_abs = start_seconds + clamped_split
-        end_seconds = parse_timestamp_to_seconds(clip["end_time"])
-
-        await self.clip_repo.update_clip(
-            self.db,
-            clip_id,
-            first_path.name,
-            str(first_path),
-            clip["start_time"],
-            self._seconds_to_mmss(split_abs),
-            clamped_split,
-            clip.get("text") or "",
-        )
-
-        await self.clip_repo.create_clip(
-            self.db,
-            task_id=task_id,
-            filename=second_path.name,
-            file_path=str(second_path),
-            start_time=self._seconds_to_mmss(split_abs),
-            end_time=self._seconds_to_mmss(end_seconds),
-            duration=max(0.1, end_seconds - split_abs),
-            text=clip.get("text") or "",
-            relevance_score=clip.get("relevance_score", 0.5),
-            reasoning=clip.get("reasoning") or "Split from original clip",
-            clip_order=clip.get("clip_order", 1) + 1,
-            virality_score=clip.get("virality_score", 0),
-            hook_score=clip.get("hook_score", 0),
-            engagement_score=clip.get("engagement_score", 0),
-            value_score=clip.get("value_score", 0),
-            shareability_score=clip.get("shareability_score", 0),
-            hook_type=clip.get("hook_type"),
-        )
-
-        await self.clip_repo.reorder_task_clips(self.db, task_id)
-        return {"message": "Clip split successfully"}
-
-    async def merge_clips(self, task_id: str, clip_ids: list[str]) -> Dict[str, Any]:
-        if len(clip_ids) < 2:
-            raise ValueError("At least two clips are required to merge")
-
-        clips = []
-        for clip_id in clip_ids:
-            clip = await self.clip_repo.get_clip_by_id(self.db, clip_id)
-            if not clip or clip["task_id"] != task_id:
-                raise ValueError("One or more clips not found")
-            clips.append(clip)
-
-        ordered = sorted(clips, key=lambda c: c.get("clip_order", 0))
-        merged_path = merge_clip_files(
-            [Path(c["file_path"]) for c in ordered],
-            Path(self.config.temp_dir) / "clips",
-        )
-
-        start_time = ordered[0]["start_time"]
-        end_time = ordered[-1]["end_time"]
-        duration = sum(float(c.get("duration", 0.0)) for c in ordered)
-        text = " ".join((c.get("text") or "").strip() for c in ordered if c.get("text"))
-
-        first = ordered[0]
-        await self.clip_repo.update_clip(
-            self.db,
-            first["id"],
-            merged_path.name,
-            str(merged_path),
-            start_time,
-            end_time,
-            duration,
-            text,
-        )
-
-        for clip in ordered[1:]:
-            await self.clip_repo.delete_clip(self.db, clip["id"])
-
-        await self.clip_repo.reorder_task_clips(self.db, task_id)
-        return {"message": "Clips merged successfully", "clip_id": first["id"]}
-
-    async def update_clip_captions(
-        self,
-        task_id: str,
-        clip_id: str,
-        caption_text: str,
-        position: str,
-        highlight_words: list[str],
-    ) -> Dict[str, Any]:
-        clip = await self.clip_repo.get_clip_by_id(self.db, clip_id)
-        if not clip or clip["task_id"] != task_id:
-            raise ValueError("Clip not found")
-
-        input_path = Path(clip["file_path"])
-        if not input_path.exists():
-            raise ValueError("Clip file not found")
-
-        output_path = overlay_custom_captions(
-            input_path,
-            Path(self.config.temp_dir) / "clips",
-            caption_text,
-            position,
-            highlight_words,
-        )
-
-        await self.clip_repo.update_clip(
-            self.db,
-            clip_id,
-            output_path.name,
-            str(output_path),
-            clip["start_time"],
-            clip["end_time"],
-            clip["duration"],
-            caption_text,
-        )
-        return (await self.clip_repo.get_clip_by_id(self.db, clip_id)) or {}
-
     async def get_performance_metrics(self) -> Dict[str, Any]:
         """Return aggregate processing performance metrics."""
         return await self.task_repo.get_performance_metrics(self.db)
 
-    @staticmethod
-    def _seconds_to_mmss(seconds: float) -> str:
-        total = max(0, int(round(seconds)))
-        minutes = total // 60
-        secs = total % 60
-        return f"{minutes:02d}:{secs:02d}"
+    _seconds_to_mmss = staticmethod(seconds_to_mmss)

--- a/backend/src/video_utils.py
+++ b/backend/src/video_utils.py
@@ -1,1153 +1,82 @@
 """
 Utility functions for video-related operations.
-Optimized for MoviePy v2, AssemblyAI integration, and high-quality output.
+
+Most of the heavy lifting lives in sibling ``_video_*`` modules; this file now
+hosts the public entry points (``create_optimized_clip``,
+``create_clips_from_segments``) and re-exports the helpers so existing
+``patch("src.video_utils.<symbol>")`` tests keep working.
 """
 
 from pathlib import Path
-from typing import List, Dict, Any, Tuple, Optional
-import os
+from typing import Any, Dict, List, Optional
 import logging
-import numpy as np
-from concurrent.futures import ThreadPoolExecutor
-import json
 
-import cv2
-from moviepy import VideoFileClip, CompositeVideoClip, TextClip, ColorClip
+from moviepy import (
+    ColorClip,
+    CompositeVideoClip,
+    TextClip,
+    VideoFileClip,
+    concatenate_videoclips,
+)
 from moviepy.video.fx import CrossFadeIn, CrossFadeOut, FadeIn, FadeOut
 
 import assemblyai as aai
-import srt
-from datetime import timedelta
+import srt  # noqa: F401 — re-exported for backwards-compatible patching
+from datetime import timedelta  # noqa: F401
 
 from .config import Config
-from .caption_templates import get_template, CAPTION_TEMPLATES
-from .font_registry import find_font_path
+from .caption_templates import get_template, CAPTION_TEMPLATES  # noqa: F401
+from .font_registry import find_font_path  # noqa: F401
+from ._video_encoder import VideoProcessor, _resolve_font_with_style  # noqa: F401
+from ._video_helpers import (
+    _chunk_words_by_speaker,  # noqa: F401
+    format_ms_to_timestamp,  # noqa: F401
+    get_safe_vertical_position,  # noqa: F401
+    get_scaled_font_size,  # noqa: F401
+    get_subtitle_max_width,  # noqa: F401
+    get_words_in_range,  # noqa: F401
+    parse_timestamp_to_seconds,
+    round_to_even,
+)
+from ._video_transitions import (  # noqa: F401
+    apply_transition_effect,
+    get_available_transitions,
+)
+from ._video_face import (
+    detect_faces_in_clip,  # noqa: F401
+    detect_optimal_crop_region,
+    filter_face_outliers,  # noqa: F401
+)
+from ._video_broll import (  # noqa: F401
+    apply_broll_to_clip,
+    create_9_16_clip,
+    insert_broll_into_clip,
+    resize_for_916,
+)
+from ._video_subtitles import (  # noqa: F401
+    create_assemblyai_subtitles,
+    create_fade_subtitles,
+    create_karaoke_subtitles,
+    create_pop_subtitles,
+    create_static_subtitles,
+)
+from ._video_transcript import (
+    cache_transcript_data,  # noqa: F401
+    format_transcript_for_analysis,  # noqa: F401
+    get_video_transcript,
+    load_cached_transcript_data,  # noqa: F401
+)
 
 logger = logging.getLogger(__name__)
 config = Config()
 TRANSCRIPT_CACHE_SCHEMA_VERSION = 2
 
 
-class VideoProcessor:
-    """Handles video processing operations with optimized settings."""
-
-    def __init__(
-        self,
-        font_family: str = "THEBOLDFONT",
-        font_size: int = 24,
-        font_color: str = "#FFFFFF",
-    ):
-        self.font_family = font_family
-        self.font_size = font_size
-        self.font_color = font_color
-        resolved_font = find_font_path(font_family, allow_all_user_fonts=True)
-        if not resolved_font:
-            resolved_font = find_font_path("TikTokSans-Regular")
-        if not resolved_font:
-            resolved_font = find_font_path("THEBOLDFONT")
-        self.font_path = str(resolved_font) if resolved_font else ""
-
-    def get_optimal_encoding_settings(
-        self, target_quality: str = "high"
-    ) -> Dict[str, Any]:
-        """Get optimal encoding settings for different quality levels."""
-        settings = {
-            "high": {
-                "codec": "libx264",
-                "audio_codec": "aac",
-                "audio_bitrate": "256k",
-                "preset": "slow",
-                "ffmpeg_params": [
-                    "-crf",
-                    "18",
-                    "-pix_fmt",
-                    "yuv420p",
-                    "-profile:v",
-                    "high",
-                    "-movflags",
-                    "+faststart",
-                    "-sws_flags",
-                    "lanczos",
-                ],
-            },
-            "medium": {
-                "codec": "libx264",
-                "audio_codec": "aac",
-                "bitrate": "4000k",
-                "audio_bitrate": "192k",
-                "preset": "fast",
-                "ffmpeg_params": ["-crf", "23", "-pix_fmt", "yuv420p"],
-            },
-        }
-        return settings.get(target_quality, settings["high"])
-
-
-def get_video_transcript(video_path: Path, speech_model: str = "best") -> str:
-    """Get transcript using AssemblyAI with word-level timing for precise subtitles."""
-    logger.info(f"Getting transcript for: {video_path}")
-
-    # Configure AssemblyAI
-    aai.settings.api_key = config.assembly_ai_api_key
-    transcriber = aai.Transcriber()
-
-    # Request word-level timestamps for precise subtitle sync
-    speech_model_value = aai.SpeechModel.best
-    if speech_model == "nano":
-        speech_model_value = aai.SpeechModel.nano
-
-    config_obj = aai.TranscriptionConfig(
-        speaker_labels=True,
-        punctuate=True,
-        format_text=True,
-        speech_model=speech_model_value,
-    )
-
-    try:
-        logger.info("Starting AssemblyAI transcription")
-        transcript = transcriber.transcribe(str(video_path), config=config_obj)
-
-        if transcript.status == aai.TranscriptStatus.error:
-            logger.error(f"AssemblyAI transcription failed: {transcript.error}")
-            raise Exception(f"Transcription failed: {transcript.error}")
-
-        formatted_lines = format_transcript_for_analysis(transcript)
-
-        # Cache the raw transcript for subtitle generation
-        cache_transcript_data(video_path, transcript)
-
-        result = "\n".join(formatted_lines)
-        logger.info(
-            f"Transcript formatted: {len(formatted_lines)} segments, {len(result)} chars"
-        )
-        return result
-
-    except Exception as e:
-        logger.error(f"Error in transcription: {e}")
-        raise
-
-
-def cache_transcript_data(video_path: Path, transcript) -> None:
-    """Cache AssemblyAI transcript data for subtitle generation."""
-    cache_path = video_path.with_suffix(".transcript_cache.json")
-
-    words_data = []
-    if transcript.words:
-        words_data = [_serialize_transcript_word(word) for word in transcript.words]
-
-    utterances_data = []
-    if getattr(transcript, "utterances", None):
-        utterances_data = [
-            {
-                "text": utterance.text,
-                "start": utterance.start,
-                "end": utterance.end,
-                "speaker": getattr(utterance, "speaker", None),
-                "words": [
-                    _serialize_transcript_word(word)
-                    for word in getattr(utterance, "words", []) or []
-                ],
-            }
-            for utterance in transcript.utterances
-        ]
-
-    cache_data = {
-        "version": TRANSCRIPT_CACHE_SCHEMA_VERSION,
-        "words": words_data,
-        "utterances": utterances_data,
-        "text": transcript.text,
-    }
-
-    with open(cache_path, "w") as f:
-        json.dump(cache_data, f)
-
-    logger.info(f"Cached {len(words_data)} words to {cache_path}")
-
-
-def load_cached_transcript_data(video_path: Path) -> Optional[Dict]:
-    """Load cached AssemblyAI transcript data."""
-    cache_path = video_path.with_suffix(".transcript_cache.json")
-
-    if not cache_path.exists():
-        return None
-
-    try:
-        with open(cache_path, "r") as f:
-            payload = json.load(f)
-            if "version" not in payload:
-                payload["version"] = TRANSCRIPT_CACHE_SCHEMA_VERSION
-                payload.setdefault("utterances", [])
-            return payload
-    except Exception as e:
-        logger.warning(f"Failed to load transcript cache: {e}")
-        return None
-
-
-def _serialize_transcript_word(word) -> Dict[str, Any]:
-    return {
-        "text": word.text,
-        "start": word.start,
-        "end": word.end,
-        "confidence": word.confidence if hasattr(word, "confidence") else 1.0,
-        "speaker": getattr(word, "speaker", None),
-    }
-
-
-def format_transcript_for_analysis(transcript) -> List[str]:
-    """Format transcripts into readable timestamped segments for AI analysis."""
-    utterances = getattr(transcript, "utterances", None) or []
-    if utterances:
-        formatted_lines = []
-        for utterance in utterances:
-            start_time = format_ms_to_timestamp(utterance.start)
-            end_time = format_ms_to_timestamp(utterance.end)
-            speaker = getattr(utterance, "speaker", None)
-            speaker_prefix = f"Speaker {speaker}: " if speaker else ""
-            formatted_lines.append(
-                f"[{start_time} - {end_time}] {speaker_prefix}{utterance.text}"
-            )
-        return formatted_lines
-
-    formatted_lines = []
-    words = getattr(transcript, "words", None) or []
-    if not words:
-        return formatted_lines
-
-    logger.info(f"Processing {len(words)} words with precise timing")
-
-    current_segment = []
-    current_start = None
-    segment_word_count = 0
-    max_words_per_segment = 8
-
-    for word in words:
-        if current_start is None:
-            current_start = word.start
-
-        current_segment.append(word.text)
-        segment_word_count += 1
-
-        if (
-            segment_word_count >= max_words_per_segment
-            or word.text.endswith(".")
-            or word.text.endswith("!")
-            or word.text.endswith("?")
-        ):
-            if current_segment:
-                start_time = format_ms_to_timestamp(current_start)
-                end_time = format_ms_to_timestamp(word.end)
-                text = " ".join(current_segment)
-                formatted_lines.append(f"[{start_time} - {end_time}] {text}")
-
-            current_segment = []
-            current_start = None
-            segment_word_count = 0
-
-    if current_segment and current_start is not None:
-        start_time = format_ms_to_timestamp(current_start)
-        end_time = format_ms_to_timestamp(words[-1].end)
-        text = " ".join(current_segment)
-        formatted_lines.append(f"[{start_time} - {end_time}] {text}")
-
-    return formatted_lines
-
-
-def format_ms_to_timestamp(ms: int) -> str:
-    """Format milliseconds to MM:SS format."""
-    seconds = ms // 1000
-    minutes = seconds // 60
-    seconds = seconds % 60
-    return f"{minutes:02d}:{seconds:02d}"
-
-
-def round_to_even(value: int) -> int:
-    """Round integer to nearest even number for H.264 compatibility."""
-    return value - (value % 2)
-
-
-def get_scaled_font_size(base_font_size: int, video_width: int) -> int:
-    """Scale caption font size by output width with sensible bounds."""
-    scaled_size = int(base_font_size * (video_width / 720))
-    return max(24, min(64, scaled_size))
-
-
-def get_subtitle_max_width(video_width: int) -> int:
-    """Return max subtitle text width with horizontal safe margins."""
-    horizontal_padding = max(40, int(video_width * 0.06))
-    return max(200, video_width - (horizontal_padding * 2))
-
-
-def get_safe_vertical_position(
-    video_height: int, text_height: int, position_y: float
-) -> int:
-    """Return subtitle y position clamped inside a top/bottom safe area."""
-    min_top_padding = max(40, int(video_height * 0.05))
-    min_bottom_padding = max(120, int(video_height * 0.10))
-
-    desired_y = int(video_height * position_y - text_height // 2)
-    max_y = video_height - min_bottom_padding - text_height
-    return max(min_top_padding, min(desired_y, max_y))
-
-
-def detect_optimal_crop_region(
-    video_clip: VideoFileClip,
-    start_time: float,
-    end_time: float,
-    target_ratio: float = 9 / 16,
-) -> Tuple[int, int, int, int]:
-    """Detect optimal crop region using improved face detection."""
-    try:
-        original_width, original_height = video_clip.size
-
-        # Calculate target dimensions and ensure they're even
-        if original_width / original_height > target_ratio:
-            new_width = round_to_even(int(original_height * target_ratio))
-            new_height = round_to_even(original_height)
-        else:
-            new_width = round_to_even(original_width)
-            new_height = round_to_even(int(original_width / target_ratio))
-
-        # Try improved face detection
-        face_centers = detect_faces_in_clip(video_clip, start_time, end_time)
-
-        # Calculate crop position
-        if face_centers:
-            # Use weighted average of face centers with temporal consistency
-            total_weight = sum(
-                area * confidence for _, _, area, confidence in face_centers
-            )
-            if total_weight > 0:
-                weighted_x = (
-                    sum(
-                        x * area * confidence for x, y, area, confidence in face_centers
-                    )
-                    / total_weight
-                )
-                weighted_y = (
-                    sum(
-                        y * area * confidence for x, y, area, confidence in face_centers
-                    )
-                    / total_weight
-                )
-
-                # Add slight bias towards upper portion for better face framing
-                weighted_y = max(0, weighted_y - new_height * 0.1)
-
-                x_offset = max(
-                    0, min(int(weighted_x - new_width // 2), original_width - new_width)
-                )
-                y_offset = max(
-                    0,
-                    min(
-                        int(weighted_y - new_height // 2), original_height - new_height
-                    ),
-                )
-
-                logger.info(
-                    f"Face-centered crop: {len(face_centers)} faces detected with improved algorithm"
-                )
-            else:
-                # Center crop
-                x_offset = (
-                    (original_width - new_width) // 2
-                    if original_width > new_width
-                    else 0
-                )
-                y_offset = (
-                    (original_height - new_height) // 2
-                    if original_height > new_height
-                    else 0
-                )
-        else:
-            # Center crop
-            x_offset = (
-                (original_width - new_width) // 2 if original_width > new_width else 0
-            )
-            y_offset = (
-                (original_height - new_height) // 2
-                if original_height > new_height
-                else 0
-            )
-            logger.info("Using center crop (no faces detected)")
-
-        # Ensure offsets are even too
-        x_offset = round_to_even(x_offset)
-        y_offset = round_to_even(y_offset)
-
-        logger.info(
-            f"Crop dimensions: {new_width}x{new_height} at offset ({x_offset}, {y_offset})"
-        )
-        return (x_offset, y_offset, new_width, new_height)
-
-    except Exception as e:
-        logger.error(f"Error in crop detection: {e}")
-        # Fallback to center crop
-        original_width, original_height = video_clip.size
-        if original_width / original_height > target_ratio:
-            new_width = round_to_even(int(original_height * target_ratio))
-            new_height = round_to_even(original_height)
-        else:
-            new_width = round_to_even(original_width)
-            new_height = round_to_even(int(original_width / target_ratio))
-
-        x_offset = (
-            round_to_even((original_width - new_width) // 2)
-            if original_width > new_width
-            else 0
-        )
-        y_offset = (
-            round_to_even((original_height - new_height) // 2)
-            if original_height > new_height
-            else 0
-        )
-
-        return (x_offset, y_offset, new_width, new_height)
-
-
-def detect_faces_in_clip(
-    video_clip: VideoFileClip, start_time: float, end_time: float
-) -> List[Tuple[int, int, int, float]]:
-    """
-    Improved face detection using multiple methods and temporal consistency.
-    Returns list of (x, y, area, confidence) tuples.
-    """
-    face_centers = []
-
-    try:
-        # Try to use MediaPipe (most accurate)
-        mp_face_detection = None
-        try:
-            import mediapipe as mp
-
-            mp_face_detection = mp.solutions.face_detection.FaceDetection(
-                model_selection=0,  # 0 for short-range (better for close faces)
-                min_detection_confidence=0.5,
-            )
-            logger.info("Using MediaPipe face detector")
-        except ImportError:
-            logger.info("MediaPipe not available, falling back to OpenCV")
-        except Exception as e:
-            logger.warning(f"MediaPipe face detector failed to initialize: {e}")
-
-        # Initialize OpenCV face detectors as fallback
-        haar_cascade = cv2.CascadeClassifier(
-            cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
-        )
-
-        # Try to load DNN face detector (more accurate than Haar)
-        dnn_net = None
-        try:
-            # Load OpenCV's DNN face detector
-            prototxt_path = cv2.data.haarcascades.replace(
-                "haarcascades", "opencv_face_detector.pbtxt"
-            )
-            model_path = cv2.data.haarcascades.replace(
-                "haarcascades", "opencv_face_detector_uint8.pb"
-            )
-
-            # If DNN model files don't exist, we'll fall back to Haar cascade
-            import os
-
-            if os.path.exists(prototxt_path) and os.path.exists(model_path):
-                dnn_net = cv2.dnn.readNetFromTensorflow(model_path, prototxt_path)
-                logger.info("OpenCV DNN face detector loaded as backup")
-            else:
-                logger.info("OpenCV DNN face detector not available")
-        except Exception:
-            logger.info("OpenCV DNN face detector failed to load")
-
-        # Sample more frames for better face detection (every 0.5 seconds)
-        duration = end_time - start_time
-        sample_interval = min(0.5, duration / 10)  # At least 10 samples, max every 0.5s
-        sample_times = []
-
-        current_time = start_time
-        while current_time < end_time:
-            sample_times.append(current_time)
-            current_time += sample_interval
-
-        # Ensure we always sample the middle and end
-        if duration > 1.0:
-            middle_time = start_time + duration / 2
-            if middle_time not in sample_times:
-                sample_times.append(middle_time)
-
-        sample_times = [t for t in sample_times if t < end_time]
-        logger.info(f"Sampling {len(sample_times)} frames for face detection")
-
-        for sample_time in sample_times:
-            try:
-                frame = video_clip.get_frame(sample_time)
-                height, width = frame.shape[:2]
-                detected_faces = []
-
-                # Try MediaPipe first (most accurate)
-                if mp_face_detection is not None:
-                    try:
-                        # MediaPipe expects RGB format
-                        results = mp_face_detection.process(frame)
-
-                        if results.detections:
-                            for detection in results.detections:
-                                bbox = detection.location_data.relative_bounding_box
-                                confidence = detection.score[0]
-
-                                # Convert relative coordinates to absolute
-                                x = int(bbox.xmin * width)
-                                y = int(bbox.ymin * height)
-                                w = int(bbox.width * width)
-                                h = int(bbox.height * height)
-
-                                if w > 30 and h > 30:  # Minimum face size
-                                    detected_faces.append((x, y, w, h, confidence))
-                    except Exception as e:
-                        logger.warning(
-                            f"MediaPipe detection failed for frame at {sample_time}s: {e}"
-                        )
-
-                # If MediaPipe didn't find faces, try DNN detector
-                if not detected_faces and dnn_net is not None:
-                    try:
-                        frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                        blob = cv2.dnn.blobFromImage(
-                            frame_bgr, 1.0, (300, 300), [104, 117, 123]
-                        )
-                        dnn_net.setInput(blob)
-                        detections = dnn_net.forward()
-
-                        for i in range(detections.shape[2]):
-                            confidence = detections[0, 0, i, 2]
-                            if confidence > 0.5:  # Confidence threshold
-                                x1 = int(detections[0, 0, i, 3] * width)
-                                y1 = int(detections[0, 0, i, 4] * height)
-                                x2 = int(detections[0, 0, i, 5] * width)
-                                y2 = int(detections[0, 0, i, 6] * height)
-
-                                w = x2 - x1
-                                h = y2 - y1
-
-                                if w > 30 and h > 30:  # Minimum face size
-                                    detected_faces.append((x1, y1, w, h, confidence))
-                    except Exception as e:
-                        logger.warning(
-                            f"DNN detection failed for frame at {sample_time}s: {e}"
-                        )
-
-                # If still no faces found, use Haar cascade
-                if not detected_faces:
-                    try:
-                        frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-                        gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
-
-                        faces = haar_cascade.detectMultiScale(
-                            gray,
-                            scaleFactor=1.05,  # More sensitive
-                            minNeighbors=3,  # Less strict
-                            minSize=(40, 40),  # Smaller minimum size
-                            maxSize=(
-                                int(width * 0.7),
-                                int(height * 0.7),
-                            ),  # Maximum size limit
-                        )
-
-                        for x, y, w, h in faces:
-                            # Estimate confidence based on face size and position
-                            face_area = w * h
-                            relative_size = face_area / (width * height)
-                            confidence = min(
-                                0.9, 0.3 + relative_size * 2
-                            )  # Rough confidence estimate
-                            detected_faces.append((x, y, w, h, confidence))
-                    except Exception as e:
-                        logger.warning(
-                            f"Haar cascade detection failed for frame at {sample_time}s: {e}"
-                        )
-
-                # Process detected faces
-                for x, y, w, h, confidence in detected_faces:
-                    face_center_x = x + w // 2
-                    face_center_y = y + h // 2
-                    face_area = w * h
-
-                    # Filter out very small or very large faces
-                    frame_area = width * height
-                    relative_area = face_area / frame_area
-
-                    if (
-                        0.005 < relative_area < 0.3
-                    ):  # Face should be 0.5% to 30% of frame
-                        face_centers.append(
-                            (face_center_x, face_center_y, face_area, confidence)
-                        )
-
-            except Exception as e:
-                logger.warning(f"Error detecting faces in frame at {sample_time}s: {e}")
-                continue
-
-        # Close MediaPipe detector
-        if mp_face_detection is not None:
-            mp_face_detection.close()
-
-        # Remove outliers (faces that are very far from the median position)
-        if len(face_centers) > 2:
-            face_centers = filter_face_outliers(face_centers)
-
-        logger.info(f"Detected {len(face_centers)} reliable face centers")
-        return face_centers
-
-    except Exception as e:
-        logger.error(f"Error in face detection: {e}")
-        return []
-
-
-def filter_face_outliers(
-    face_centers: List[Tuple[int, int, int, float]],
-) -> List[Tuple[int, int, int, float]]:
-    """Remove face detections that are outliers (likely false positives)."""
-    if len(face_centers) < 3:
-        return face_centers
-
-    try:
-        # Calculate median position
-        x_positions = [x for x, y, area, conf in face_centers]
-        y_positions = [y for x, y, area, conf in face_centers]
-
-        median_x = np.median(x_positions)
-        median_y = np.median(y_positions)
-
-        # Calculate standard deviation
-        std_x = np.std(x_positions)
-        std_y = np.std(y_positions)
-
-        # Filter out faces that are more than 2 standard deviations away
-        filtered_faces = []
-        for face in face_centers:
-            x, y, area, conf = face
-            if abs(x - median_x) <= 2 * std_x and abs(y - median_y) <= 2 * std_y:
-                filtered_faces.append(face)
-
-        logger.info(
-            f"Filtered {len(face_centers)} -> {len(filtered_faces)} faces (removed outliers)"
-        )
-        return (
-            filtered_faces if filtered_faces else face_centers
-        )  # Return original if all filtered
-
-    except Exception as e:
-        logger.warning(f"Error filtering face outliers: {e}")
-        return face_centers
-
-
-def parse_timestamp_to_seconds(timestamp_str: str) -> float:
-    """Parse timestamp string to seconds."""
-    try:
-        timestamp_str = timestamp_str.strip()
-        logger.info(f"Parsing timestamp: '{timestamp_str}'")  # Debug logging
-
-        if ":" in timestamp_str:
-            parts = timestamp_str.split(":")
-            if len(parts) == 2:
-                minutes, seconds = map(int, parts)
-                result = minutes * 60 + seconds
-                logger.info(f"Parsed '{timestamp_str}' -> {result}s")
-                return result
-            elif len(parts) == 3:  # HH:MM:SS format
-                hours, minutes, seconds = map(int, parts)
-                result = hours * 3600 + minutes * 60 + seconds
-                logger.info(f"Parsed '{timestamp_str}' -> {result}s")
-                return result
-
-        # Try parsing as pure seconds
-        result = float(timestamp_str)
-        logger.info(f"Parsed '{timestamp_str}' as seconds -> {result}s")
-        return result
-
-    except (ValueError, IndexError) as e:
-        logger.error(f"Failed to parse timestamp '{timestamp_str}': {e}")
-        return 0.0
-
-
-def get_words_in_range(
-    transcript_data: Dict, clip_start: float, clip_end: float
-) -> List[Dict]:
-    """Extract words that fall within a clip timerange."""
-    if not transcript_data or not transcript_data.get("words"):
-        return []
-
-    clip_start_ms = int(clip_start * 1000)
-    clip_end_ms = int(clip_end * 1000)
-
-    relevant_words = []
-    for word_data in transcript_data["words"]:
-        word_start = word_data["start"]
-        word_end = word_data["end"]
-
-        if word_start < clip_end_ms and word_end > clip_start_ms:
-            relative_start = max(0, (word_start - clip_start_ms) / 1000.0)
-            relative_end = min(
-                (clip_end_ms - clip_start_ms) / 1000.0,
-                (word_end - clip_start_ms) / 1000.0,
-            )
-
-            if relative_end > relative_start:
-                relevant_words.append(
-                    {
-                        "text": word_data["text"],
-                        "start": relative_start,
-                        "end": relative_end,
-                        "confidence": word_data.get("confidence", 1.0),
-                    }
-                )
-
-    return relevant_words
-
-
-def create_assemblyai_subtitles(
-    video_path: Path,
-    clip_start: float,
-    clip_end: float,
-    video_width: int,
-    video_height: int,
-    font_family: str = "THEBOLDFONT",
-    font_size: int = 24,
-    font_color: str = "#FFFFFF",
-    caption_template: str = "default",
-) -> List[TextClip]:
-    """Create subtitles using AssemblyAI's precise word timing with template support."""
-    transcript_data = load_cached_transcript_data(video_path)
-
-    if not transcript_data or not transcript_data.get("words"):
-        logger.warning("No cached transcript data available for subtitles")
-        return []
-
-    # Get template settings
-    template = get_template(caption_template)
-    animation_type = template.get("animation", "none")
-
-    effective_font_family = font_family or template["font_family"]
-    effective_font_size = int(font_size) if font_size else int(template["font_size"])
-    effective_font_color = font_color or template["font_color"]
-    effective_template = {
-        **template,
-        "font_size": effective_font_size,
-        "font_color": effective_font_color,
-        "font_family": effective_font_family,
-    }
-
-    logger.info(
-        f"Creating subtitles with template '{caption_template}', animation: {animation_type}"
-    )
-
-    # Get words in range
-    relevant_words = get_words_in_range(transcript_data, clip_start, clip_end)
-
-    if not relevant_words:
-        logger.warning("No words found in clip timerange")
-        return []
-
-    # Choose subtitle creation method based on animation type
-    if animation_type == "karaoke":
-        return create_karaoke_subtitles(
-            relevant_words,
-            video_width,
-            video_height,
-            effective_template,
-            effective_font_family,
-        )
-    elif animation_type == "pop":
-        return create_pop_subtitles(
-            relevant_words,
-            video_width,
-            video_height,
-            effective_template,
-            effective_font_family,
-        )
-    elif animation_type == "fade":
-        return create_fade_subtitles(
-            relevant_words,
-            video_width,
-            video_height,
-            effective_template,
-            effective_font_family,
-        )
-    else:
-        # Default static subtitles
-        return create_static_subtitles(
-            relevant_words,
-            video_width,
-            video_height,
-            effective_template,
-            effective_font_family,
-        )
-
-
-def create_static_subtitles(
-    relevant_words: List[Dict],
-    video_width: int,
-    video_height: int,
-    template: Dict,
-    font_family: str,
-) -> List[TextClip]:
-    """Create standard static subtitles (original behavior)."""
-    subtitle_clips = []
-    processor = VideoProcessor(
-        font_family, template["font_size"], template["font_color"]
-    )
-
-    calculated_font_size = get_scaled_font_size(template["font_size"], video_width)
-    position_y = template.get("position_y", 0.75)
-    max_text_width = get_subtitle_max_width(video_width)
-
-    words_per_subtitle = 3
-    for i in range(0, len(relevant_words), words_per_subtitle):
-        word_group = relevant_words[i : i + words_per_subtitle]
-        if not word_group:
-            continue
-
-        segment_start = word_group[0]["start"]
-        segment_end = word_group[-1]["end"]
-        segment_duration = segment_end - segment_start
-
-        if segment_duration < 0.1:
-            continue
-
-        text = " ".join(word["text"] for word in word_group)
-
-        try:
-            stroke_color = template.get("stroke_color", "black")
-            stroke_width = template.get("stroke_width", 1)
-
-            text_clip = (
-                TextClip(
-                    text=text,
-                    font=processor.font_path,
-                    font_size=calculated_font_size,
-                    color=template["font_color"],
-                    stroke_color=stroke_color if stroke_color else None,
-                    stroke_width=stroke_width if stroke_color else 0,
-                    method="caption",
-                    size=(max_text_width, None),
-                    text_align="center",
-                    interline=6,
-                )
-                .with_duration(segment_duration)
-                .with_start(segment_start)
-            )
-
-            text_height = text_clip.size[1] if text_clip.size else 40
-            vertical_position = get_safe_vertical_position(
-                video_height, text_height, position_y
-            )
-            text_clip = text_clip.with_position(("center", vertical_position))
-
-            subtitle_clips.append(text_clip)
-
-        except Exception as e:
-            logger.warning(f"Failed to create subtitle for '{text}': {e}")
-            continue
-
-    logger.info(f"Created {len(subtitle_clips)} static subtitle elements")
-    return subtitle_clips
-
-
-def create_karaoke_subtitles(
-    relevant_words: List[Dict],
-    video_width: int,
-    video_height: int,
-    template: Dict,
-    font_family: str,
-) -> List[TextClip]:
-    """Create karaoke-style subtitles with word-by-word highlighting."""
-    subtitle_clips = []
-    processor = VideoProcessor(
-        font_family, template["font_size"], template["font_color"]
-    )
-
-    calculated_font_size = get_scaled_font_size(template["font_size"], video_width)
-    position_y = template.get("position_y", 0.75)
-    highlight_color = template.get("highlight_color", "#FFD700")
-    normal_color = template["font_color"]
-    max_text_width = get_subtitle_max_width(video_width)
-    horizontal_padding = max(40, int(video_width * 0.06))
-
-    words_per_group = 3
-
-    def measure_word_group_width(word_group: List[Dict], font_size: int) -> List[int]:
-        widths: List[int] = []
-        for word in word_group:
-            temp_clip = TextClip(
-                text=word["text"],
-                font=processor.font_path,
-                font_size=font_size,
-                color=normal_color,
-                stroke_color=template.get("stroke_color", "black"),
-                stroke_width=template.get("stroke_width", 1),
-                method="label",
-            )
-            widths.append(temp_clip.size[0] if temp_clip.size else 50)
-            temp_clip.close()
-        return widths
-
-    for group_idx in range(0, len(relevant_words), words_per_group):
-        word_group = relevant_words[group_idx : group_idx + words_per_group]
-        if not word_group:
-            continue
-
-        group_start = word_group[0]["start"]
-        group_end = word_group[-1]["end"]
-
-        # For each word in the group, create a highlighted version
-        for word_idx, current_word in enumerate(word_group):
-            word_start = current_word["start"]
-            word_end = current_word["end"]
-            word_duration = word_end - word_start
-
-            if word_duration < 0.05:
-                continue
-
-            try:
-                # Build the text with the current word highlighted
-                # We create individual text clips for each word and composite them
-                word_clips_for_composite = []
-                font_size_for_group = calculated_font_size
-                word_widths = measure_word_group_width(word_group, font_size_for_group)
-                space_width = font_size_for_group * 0.28
-                total_width = sum(word_widths) + space_width * (len(word_group) - 1)
-
-                if total_width > max_text_width and total_width > 0:
-                    shrink_ratio = max_text_width / total_width
-                    font_size_for_group = max(
-                        20, int(font_size_for_group * shrink_ratio)
-                    )
-                    word_widths = measure_word_group_width(
-                        word_group, font_size_for_group
-                    )
-                    space_width = font_size_for_group * 0.28
-                    total_width = sum(word_widths) + space_width * (len(word_group) - 1)
-
-                # Second pass: create positioned clips
-                current_x = max(horizontal_padding, (video_width - total_width) / 2)
-                text_height = 40
-
-                for w_idx, word in enumerate(word_group):
-                    is_current = w_idx == word_idx
-                    color = highlight_color if is_current else normal_color
-                    # Scale up current word slightly for pop effect
-                    size_multiplier = 1.1 if is_current else 1.0
-
-                    word_clip = (
-                        TextClip(
-                            text=word["text"],
-                            font=processor.font_path,
-                            font_size=int(font_size_for_group * size_multiplier),
-                            color=color,
-                            stroke_color=template.get("stroke_color", "black"),
-                            stroke_width=template.get("stroke_width", 1),
-                            method="label",
-                        )
-                        .with_duration(word_duration)
-                        .with_start(word_start)
-                    )
-
-                    text_height = max(
-                        text_height, word_clip.size[1] if word_clip.size else 40
-                    )
-                    vertical_position = get_safe_vertical_position(
-                        video_height, text_height, position_y
-                    )
-
-                    word_clip = word_clip.with_position(
-                        (int(current_x), vertical_position)
-                    )
-                    word_clips_for_composite.append(word_clip)
-
-                    current_x += word_widths[w_idx] + space_width
-
-                subtitle_clips.extend(word_clips_for_composite)
-
-            except Exception as e:
-                logger.warning(
-                    f"Failed to create karaoke subtitle for word '{current_word['text']}': {e}"
-                )
-                continue
-
-    logger.info(f"Created {len(subtitle_clips)} karaoke subtitle elements")
-    return subtitle_clips
-
-
-def create_pop_subtitles(
-    relevant_words: List[Dict],
-    video_width: int,
-    video_height: int,
-    template: Dict,
-    font_family: str,
-) -> List[TextClip]:
-    """Create pop-style subtitles where each word pops in."""
-    subtitle_clips = []
-    processor = VideoProcessor(
-        font_family, template["font_size"], template["font_color"]
-    )
-
-    calculated_font_size = get_scaled_font_size(template["font_size"], video_width)
-    position_y = template.get("position_y", 0.75)
-    max_text_width = get_subtitle_max_width(video_width)
-
-    words_per_group = 3
-
-    for group_idx in range(0, len(relevant_words), words_per_group):
-        word_group = relevant_words[group_idx : group_idx + words_per_group]
-        if not word_group:
-            continue
-
-        # Show the full group text
-        group_text = " ".join(w["text"] for w in word_group)
-        group_start = word_group[0]["start"]
-        group_end = word_group[-1]["end"]
-        group_duration = group_end - group_start
-
-        if group_duration < 0.1:
-            continue
-
-        try:
-            # Create main text clip
-            text_clip = (
-                TextClip(
-                    text=group_text,
-                    font=processor.font_path,
-                    font_size=calculated_font_size,
-                    color=template["font_color"],
-                    stroke_color=template.get("stroke_color", "black"),
-                    stroke_width=template.get("stroke_width", 2),
-                    method="caption",
-                    size=(max_text_width, None),
-                    text_align="center",
-                    interline=6,
-                )
-                .with_duration(group_duration)
-                .with_start(group_start)
-            )
-
-            text_height = text_clip.size[1] if text_clip.size else 40
-            vertical_position = get_safe_vertical_position(
-                video_height, text_height, position_y
-            )
-            text_clip = text_clip.with_position(("center", vertical_position))
-
-            subtitle_clips.append(text_clip)
-
-        except Exception as e:
-            logger.warning(f"Failed to create pop subtitle: {e}")
-            continue
-
-    logger.info(f"Created {len(subtitle_clips)} pop subtitle elements")
-    return subtitle_clips
-
-
-def create_fade_subtitles(
-    relevant_words: List[Dict],
-    video_width: int,
-    video_height: int,
-    template: Dict,
-    font_family: str,
-) -> List[TextClip]:
-    """Create fade-style subtitles with smooth transitions."""
-    subtitle_clips = []
-    processor = VideoProcessor(
-        font_family, template["font_size"], template["font_color"]
-    )
-
-    calculated_font_size = get_scaled_font_size(template["font_size"], video_width)
-    position_y = template.get("position_y", 0.75)
-    has_background = template.get("background", False)
-    background_color = template.get("background_color", "#00000080")
-    max_text_width = get_subtitle_max_width(video_width)
-
-    words_per_group = 4
-
-    for group_idx in range(0, len(relevant_words), words_per_group):
-        word_group = relevant_words[group_idx : group_idx + words_per_group]
-        if not word_group:
-            continue
-
-        group_text = " ".join(w["text"] for w in word_group)
-        group_start = word_group[0]["start"]
-        group_end = word_group[-1]["end"]
-        group_duration = group_end - group_start
-
-        if group_duration < 0.1:
-            continue
-
-        try:
-            # Create text clip
-            text_clip = TextClip(
-                text=group_text,
-                font=processor.font_path,
-                font_size=calculated_font_size,
-                color=template["font_color"],
-                stroke_color=template.get("stroke_color")
-                if template.get("stroke_color")
-                else None,
-                stroke_width=template.get("stroke_width", 0),
-                method="caption",
-                size=(max_text_width, None),
-                text_align="center",
-                interline=6,
-            )
-
-            text_height = text_clip.size[1] if text_clip.size else 40
-            text_width = text_clip.size[0] if text_clip.size else 200
-            vertical_position = get_safe_vertical_position(
-                video_height, text_height, position_y
-            )
-
-            # Add background if specified
-            if has_background and background_color:
-                padding = 10
-                # Parse background color (handle alpha)
-                bg_color_hex = (
-                    background_color[:7]
-                    if len(background_color) > 7
-                    else background_color
-                )
-
-                bg_clip = (
-                    ColorClip(
-                        size=(text_width + padding * 2, text_height + padding),
-                        color=tuple(
-                            int(bg_color_hex[i : i + 2], 16) for i in (1, 3, 5)
-                        ),
-                    )
-                    .with_duration(group_duration)
-                    .with_start(group_start)
-                )
-
-                bg_clip = bg_clip.with_position(
-                    ("center", vertical_position - padding // 2)
-                )
-
-                # Apply fade to background
-                fade_duration = min(0.2, group_duration / 4)
-                bg_clip = (
-                    bg_clip.with_effects(
-                        [CrossFadeIn(fade_duration), CrossFadeOut(fade_duration)]
-                    )
-                    if group_duration > 0.5
-                    else bg_clip
-                )
-
-                subtitle_clips.append(bg_clip)
-
-            # Apply timing and position to text
-            text_clip = text_clip.with_duration(group_duration).with_start(group_start)
-            text_clip = text_clip.with_position(("center", vertical_position))
-
-            subtitle_clips.append(text_clip)
-
-        except Exception as e:
-            logger.warning(f"Failed to create fade subtitle: {e}")
-            continue
-
-    logger.info(f"Created {len(subtitle_clips)} fade subtitle elements")
-    return subtitle_clips
+# Fraction of the source height to crop away when the user marks the original
+# video as having burned-in subtitles on the top or bottom band. Trimming this
+# strip before face-tracked crop pushes the original text fully out of frame,
+# so our new subtitles can render at their normal position over clean pixels.
+ORIGINAL_SUBTITLE_BAND_FRACTION = 0.15
 
 
 def create_optimized_clip(
@@ -1161,18 +90,36 @@ def create_optimized_clip(
     font_color: str = "#FFFFFF",
     caption_template: str = "default",
     output_format: str = "vertical",
+    stroke_color_override: Optional[str] = None,
+    stroke_width_override: Optional[int] = None,
+    bold: bool = False,
+    italic: bool = False,
+    underline: bool = False,
+    avoid_original_subtitle: str = "none",
 ) -> bool:
-    """Create clip with optional subtitles. output_format: 'vertical' (9:16) or 'original' (keep source size)."""
+    """Create clip with optional subtitles.
+
+    output_format:
+      - 'vertical' (default): face-centered 9:16 crop
+      - 'fit': letterbox-blur 9:16 (full source centered on blurred background)
+      - 'original': keep source aspect ratio, no crop/resize
+      - 'capcut': same as 'original' but paired with the CapCut export path —
+        subtitles and B-roll are never burned in so the user can edit them as
+        real tracks after opening the draft in CapCut.
+    """
     try:
         duration = end_time - start_time
         if duration <= 0:
             logger.error(f"Invalid clip duration: {duration:.1f}s")
             return False
 
-        keep_original = output_format == "original"
+        # CapCut edit mode keeps the clip as-is for maximum edit-ability in
+        # CapCut; the rendering path is identical to 'original'.
+        keep_original = output_format in ("original", "capcut")
+        fit_mode = output_format == "fit"
         logger.info(
             f"Creating clip: {start_time:.1f}s - {end_time:.1f}s ({duration:.1f}s) "
-            f"subtitles={add_subtitles} template '{caption_template}' format={'original' if keep_original else 'vertical'}"
+            f"subtitles={add_subtitles} template '{caption_template}' format={output_format}"
         )
 
         # Fast path: no subtitles + original = ffmpeg stream copy (no re-encoding)
@@ -1199,7 +146,6 @@ def create_optimized_clip(
             logger.info(f"Successfully created clip (stream copy): {output_path}")
             return True
 
-        # Load and process video
         video = VideoFileClip(str(video_path))
 
         if start_time >= video.duration:
@@ -1209,29 +155,59 @@ def create_optimized_clip(
             video.close()
             return False
 
+        # Crop away the top/bottom strip that holds the original burned-in
+        # subtitles so they fall outside the frame before the 9:16 crop runs.
+        if avoid_original_subtitle in ("bottom", "top"):
+            orig_h = video.h
+            band_px = int(orig_h * ORIGINAL_SUBTITLE_BAND_FRACTION)
+            if band_px > 0 and band_px < orig_h:
+                if avoid_original_subtitle == "bottom":
+                    video = video.cropped(y1=0, y2=orig_h - band_px)
+                else:
+                    video = video.cropped(y1=band_px, y2=orig_h)
+                logger.info(
+                    f"Cropped {avoid_original_subtitle} band ({band_px}px / "
+                    f"{ORIGINAL_SUBTITLE_BAND_FRACTION * 100:.0f}%) to hide "
+                    f"original subtitles; new size {video.w}x{video.h}"
+                )
+
         end_time = min(end_time, video.duration)
         clip = video.subclipped(start_time, end_time)
 
         if keep_original:
-            # No face detection, no crop, no resize - use trimmed clip as-is
             processed_clip = clip
             target_width = round_to_even(processed_clip.w)
             target_height = round_to_even(processed_clip.h)
             if (target_width, target_height) != (processed_clip.w, processed_clip.h):
                 processed_clip = processed_clip.resized((target_width, target_height))
             cropped_clip = None
+        elif fit_mode:
+            # Fit-with-blur mode: keep the full source centered, fill the
+            # surrounding 9:16 area with a blurred zoomed copy. Face is never
+            # clipped. Isolated branch — remove to disable without touching
+            # the legacy crop path below.
+            from .fit_renderer import apply_fit_with_blur
+            composite, target_width, target_height = apply_fit_with_blur(
+                clip, target_ratio=9 / 16
+            )
+            processed_clip = composite
+            cropped_clip = None
         else:
-            # Vertical 9:16: face-centered crop, preserve native resolution
             x_offset, y_offset, new_width, new_height = detect_optimal_crop_region(
                 video, start_time, end_time, target_ratio=9 / 16
             )
             cropped_clip = clip.cropped(
-                x1=x_offset, y1=y_offset, x2=x_offset + new_width, y2=y_offset + new_height
+                x1=x_offset,
+                y1=y_offset,
+                x2=x_offset + new_width,
+                y2=y_offset + new_height,
             )
-            target_width, target_height = round_to_even(new_width), round_to_even(new_height)
+            target_width, target_height = (
+                round_to_even(new_width),
+                round_to_even(new_height),
+            )
             processed_clip = cropped_clip
 
-        # Add AssemblyAI subtitles with template support
         final_clips = [processed_clip]
 
         if add_subtitles:
@@ -1245,10 +221,15 @@ def create_optimized_clip(
                 font_size,
                 font_color,
                 caption_template,
+                stroke_color_override=stroke_color_override,
+                stroke_width_override=stroke_width_override,
+                bold=bold,
+                italic=italic,
+                underline=underline,
+                avoid_original_subtitle=avoid_original_subtitle,
             )
             final_clips.extend(subtitle_clips)
 
-        # Compose and encode
         final_clip = (
             CompositeVideoClip(final_clips) if len(final_clips) > 1 else processed_clip
         )
@@ -1266,7 +247,6 @@ def create_optimized_clip(
             **encoding_settings,
         )
 
-        # Cleanup
         if final_clip is not processed_clip:
             final_clip.close()
         if processed_clip is not cropped_clip:
@@ -1305,7 +285,6 @@ def create_clips_from_segments(
 
     for i, segment in enumerate(segments):
         try:
-            # Debug log the segment data
             logger.info(
                 f"Processing segment {i + 1}: start='{segment.get('start_time')}', end='{segment.get('end_time')}'"
             )
@@ -1351,7 +330,6 @@ def create_clips_from_segments(
                     "text": segment["text"],
                     "relevance_score": segment["relevance_score"],
                     "reasoning": segment["reasoning"],
-                    # Include virality data if available
                     "virality_score": segment.get("virality_score", 0),
                     "hook_score": segment.get("hook_score", 0),
                     "engagement_score": segment.get("engagement_score", 0),
@@ -1369,118 +347,6 @@ def create_clips_from_segments(
 
     logger.info(f"Successfully created {len(clips_info)}/{len(segments)} clips")
     return clips_info
-
-
-def get_available_transitions() -> List[str]:
-    """Get list of available transition video files."""
-    transitions_dir = Path(__file__).parent.parent / "transitions"
-    if not transitions_dir.exists():
-        logger.warning("Transitions directory not found")
-        return []
-
-    transition_files = []
-    for file_path in transitions_dir.glob("*.mp4"):
-        transition_files.append(str(file_path))
-
-    logger.info(f"Found {len(transition_files)} transition files")
-    return transition_files
-
-
-def apply_transition_effect(
-    clip1_path: Path, clip2_path: Path, transition_path: Path, output_path: Path
-) -> bool:
-    """Apply transition effect between two clips using a transition video."""
-    clip1 = None
-    clip2 = None
-    transition = None
-    clip1_tail = None
-    clip2_intro = None
-    clip2_remainder = None
-    intro_segment = None
-    final_clip = None
-
-    try:
-        from moviepy import VideoFileClip, CompositeVideoClip, concatenate_videoclips
-
-        # Load clips
-        clip1 = VideoFileClip(str(clip1_path))
-        clip2 = VideoFileClip(str(clip2_path))
-        transition = VideoFileClip(str(transition_path))
-
-        # Keep the transition window within both clips so the output still matches
-        # the current clip's duration and metadata.
-        transition_duration = min(1.5, transition.duration, clip1.duration, clip2.duration)
-        if transition_duration <= 0:
-            logger.warning("Transition duration is zero, skipping transition effect")
-            return False
-
-        transition = transition.subclipped(0, transition_duration)
-
-        # Resize transition to match clip dimensions
-        clip_size = clip2.size
-        transition = transition.resized(clip_size)
-
-        # Build a transition intro from the previous clip tail over the first
-        # part of the current clip so the exported file keeps clip2's duration.
-        clip1_tail_start = max(0, clip1.duration - transition_duration)
-        clip1_tail = clip1.subclipped(clip1_tail_start, clip1.duration).with_effects(
-            [FadeOut(transition_duration)]
-        )
-        clip2_intro = clip2.subclipped(0, transition_duration).with_effects(
-            [FadeIn(transition_duration)]
-        )
-
-        intro_segment = CompositeVideoClip(
-            [clip1_tail, clip2_intro, transition], size=clip_size
-        ).with_duration(transition_duration)
-        if clip2_intro.audio is not None:
-            intro_segment = intro_segment.with_audio(clip2_intro.audio)
-
-        final_segments = [intro_segment]
-        if clip2.duration > transition_duration:
-            clip2_remainder = clip2.subclipped(transition_duration, clip2.duration)
-            final_segments.append(clip2_remainder)
-
-        final_clip = (
-            concatenate_videoclips(final_segments, method="compose")
-            if len(final_segments) > 1
-            else intro_segment
-        )
-
-        # Write output
-        processor = VideoProcessor()
-        encoding_settings = processor.get_optimal_encoding_settings("high")
-
-        final_clip.write_videofile(
-            str(output_path),
-            temp_audiofile="temp-audio.m4a",
-            remove_temp=True,
-            logger=None,
-            **encoding_settings,
-        )
-
-        logger.info(f"Applied transition effect: {output_path}")
-        return True
-
-    except Exception as e:
-        logger.error(f"Error applying transition effect: {e}")
-        return False
-    finally:
-        for clip in (
-            final_clip,
-            intro_segment,
-            clip2_remainder,
-            clip2_intro,
-            clip1_tail,
-            transition,
-            clip2,
-            clip1,
-        ):
-            if clip is not None:
-                try:
-                    clip.close()
-                except Exception:
-                    pass
 
 
 def create_clips_with_transitions(
@@ -1517,243 +383,6 @@ def create_clips_with_transitions(
     )
 
 
-# Backward compatibility functions
 def get_video_transcript_with_assemblyai(path: Path) -> str:
     """Backward compatibility wrapper."""
     return get_video_transcript(path)
-
-
-def create_9_16_clip(
-    video_path: Path,
-    start_time: float,
-    end_time: float,
-    output_path: Path,
-    subtitle_text: str = "",
-) -> bool:
-    """Backward compatibility wrapper."""
-    return create_optimized_clip(
-        video_path, start_time, end_time, output_path, add_subtitles=bool(subtitle_text)
-    )
-
-
-# B-Roll compositing functions
-
-
-def insert_broll_into_clip(
-    main_clip_path: Path,
-    broll_path: Path,
-    insert_time: float,
-    broll_duration: float,
-    output_path: Path,
-    transition_duration: float = 0.3,
-) -> bool:
-    """
-    Insert B-roll footage into a clip at a specified timestamp.
-
-    Args:
-        main_clip_path: Path to the main video clip
-        broll_path: Path to the B-roll video
-        insert_time: When to insert B-roll (seconds from clip start)
-        broll_duration: How long to show B-roll (seconds)
-        output_path: Where to save the composited clip
-        transition_duration: Crossfade duration (seconds)
-
-    Returns:
-        True if successful
-    """
-    try:
-        from moviepy import VideoFileClip, CompositeVideoClip, concatenate_videoclips
-        from moviepy.video.fx import CrossFadeIn, CrossFadeOut
-
-        # Load clips
-        main_clip = VideoFileClip(str(main_clip_path))
-        broll_clip = VideoFileClip(str(broll_path))
-
-        # Get main clip dimensions
-        target_width, target_height = main_clip.size
-
-        # Resize B-roll to match main clip (9:16 aspect ratio)
-        broll_resized = resize_for_916(broll_clip, target_width, target_height)
-
-        # Ensure B-roll doesn't exceed requested duration
-        actual_broll_duration = min(broll_duration, broll_resized.duration)
-        broll_trimmed = broll_resized.subclipped(0, actual_broll_duration)
-
-        # Ensure insert_time is within clip bounds
-        insert_time = max(0, min(insert_time, main_clip.duration - 0.5))
-
-        # Calculate end time for B-roll
-        broll_end_time = insert_time + actual_broll_duration
-
-        # Don't let B-roll extend past the main clip
-        if broll_end_time > main_clip.duration:
-            broll_end_time = main_clip.duration
-            actual_broll_duration = broll_end_time - insert_time
-            broll_trimmed = broll_resized.subclipped(0, actual_broll_duration)
-
-        # Split main clip into three parts
-        part1 = main_clip.subclipped(0, insert_time) if insert_time > 0 else None
-        part2_audio = main_clip.subclipped(insert_time, broll_end_time).audio
-        part3 = (
-            main_clip.subclipped(broll_end_time)
-            if broll_end_time < main_clip.duration
-            else None
-        )
-
-        # Apply crossfade to B-roll
-        if transition_duration > 0:
-            broll_with_audio = broll_trimmed.with_audio(part2_audio)
-            broll_faded = broll_with_audio.with_effects(
-                [CrossFadeIn(transition_duration), CrossFadeOut(transition_duration)]
-            )
-        else:
-            broll_faded = broll_trimmed.with_audio(part2_audio)
-
-        # Concatenate parts
-        clips_to_concat = []
-        if part1:
-            clips_to_concat.append(part1)
-        clips_to_concat.append(broll_faded)
-        if part3:
-            clips_to_concat.append(part3)
-
-        if len(clips_to_concat) == 1:
-            final_clip = clips_to_concat[0]
-        else:
-            final_clip = concatenate_videoclips(clips_to_concat, method="compose")
-
-        # Write output
-        processor = VideoProcessor()
-        encoding_settings = processor.get_optimal_encoding_settings("high")
-
-        final_clip.write_videofile(
-            str(output_path),
-            temp_audiofile="temp-audio-broll.m4a",
-            remove_temp=True,
-            logger=None,
-            **encoding_settings,
-        )
-
-        # Cleanup
-        final_clip.close()
-        main_clip.close()
-        broll_clip.close()
-        broll_resized.close()
-
-        logger.info(
-            f"Inserted B-roll at {insert_time:.1f}s ({actual_broll_duration:.1f}s duration): {output_path}"
-        )
-        return True
-
-    except Exception as e:
-        logger.error(f"Error inserting B-roll: {e}")
-        return False
-
-
-def resize_for_916(
-    clip: VideoFileClip, target_width: int, target_height: int
-) -> VideoFileClip:
-    """
-    Resize a video clip to fit 9:16 aspect ratio with center crop.
-
-    Args:
-        clip: Input video clip
-        target_width: Target width
-        target_height: Target height
-
-    Returns:
-        Resized video clip
-    """
-    clip_width, clip_height = clip.size
-    target_aspect = target_width / target_height
-    clip_aspect = clip_width / clip_height
-
-    if clip_aspect > target_aspect:
-        # Clip is wider - scale to height and crop width
-        scale_factor = target_height / clip_height
-        new_width = int(clip_width * scale_factor)
-        new_height = target_height
-        resized = clip.resized((new_width, new_height))
-
-        # Center crop
-        x_offset = (new_width - target_width) // 2
-        cropped = resized.cropped(x1=x_offset, x2=x_offset + target_width)
-    else:
-        # Clip is taller - scale to width and crop height
-        scale_factor = target_width / clip_width
-        new_width = target_width
-        new_height = int(clip_height * scale_factor)
-        resized = clip.resized((new_width, new_height))
-
-        # Center crop (crop from top for portrait videos)
-        y_offset = (new_height - target_height) // 4  # Bias towards top
-        cropped = resized.cropped(y1=y_offset, y2=y_offset + target_height)
-
-    return cropped
-
-
-def apply_broll_to_clip(
-    clip_path: Path, broll_suggestions: List[Dict[str, Any]], output_path: Path
-) -> bool:
-    """
-    Apply multiple B-roll insertions to a clip.
-
-    Args:
-        clip_path: Path to the main clip
-        broll_suggestions: List of B-roll suggestions with local_path, timestamp, duration
-        output_path: Where to save the final clip
-
-    Returns:
-        True if successful
-    """
-    if not broll_suggestions:
-        logger.info("No B-roll suggestions to apply")
-        return False
-
-    try:
-        # Sort suggestions by timestamp (process from end to start to preserve timing)
-        sorted_suggestions = sorted(
-            broll_suggestions, key=lambda x: x.get("timestamp", 0), reverse=True
-        )
-
-        current_clip_path = clip_path
-        temp_paths = []
-
-        for i, suggestion in enumerate(sorted_suggestions):
-            broll_path = suggestion.get("local_path")
-            if not broll_path or not Path(broll_path).exists():
-                logger.warning(f"B-roll file not found: {broll_path}")
-                continue
-
-            timestamp = suggestion.get("timestamp", 0)
-            duration = suggestion.get("duration", 3.0)
-
-            # Create temp output for intermediate clips
-            if i < len(sorted_suggestions) - 1:
-                temp_output = output_path.parent / f"temp_broll_{i}.mp4"
-                temp_paths.append(temp_output)
-            else:
-                temp_output = output_path
-
-            success = insert_broll_into_clip(
-                current_clip_path, Path(broll_path), timestamp, duration, temp_output
-            )
-
-            if success:
-                current_clip_path = temp_output
-            else:
-                logger.warning(f"Failed to insert B-roll at {timestamp}s")
-
-        # Cleanup temp files
-        for temp_path in temp_paths:
-            if temp_path.exists() and temp_path != output_path:
-                try:
-                    temp_path.unlink()
-                except Exception:
-                    pass
-
-        return True
-
-    except Exception as e:
-        logger.error(f"Error applying B-roll to clip: {e}")
-        return False

--- a/backend/src/youtube_utils.py
+++ b/backend/src/youtube_utils.py
@@ -1,268 +1,44 @@
 """
 Utility functions for YouTube-related operations.
-Optimized for Apify-first downloads with direct yt-dlp fallback.
+
+Thin entry point: parsers live in ``_youtube_parsers``, filesystem/subprocess
+helpers in ``_youtube_io``, and the yt-dlp option presets in
+``_youtube_downloader``. This module keeps the public fetch/download entry
+points and re-exports the helpers so existing ``patch("src.youtube_utils.*")``
+tests keep working.
 """
 
 import asyncio
-from datetime import datetime
 import logging
-import re
-import subprocess
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
-from urllib.parse import parse_qs, urlparse
 
 import requests
 import yt_dlp
 
 from .apify_youtube_downloader import ApifyDownloadError, download_video_via_apify
 from .config import get_config
+from ._youtube_downloader import YouTubeDownloader
+from ._youtube_io import (
+    _build_info_options,
+    _empty_video_info,
+    _get_local_video_dimensions,
+    _remove_cached_downloads,
+)
+from ._youtube_parsers import (
+    YOUTUBE_DATA_API_URL,
+    YOUTUBE_METADATA_PROVIDER_DATA_API,
+    YOUTUBE_METADATA_PROVIDER_YTDLP,
+    _normalize_upload_date,
+    _parse_iso8601_duration_to_seconds,
+    _parse_optional_int,
+    _pick_best_thumbnail,
+    get_youtube_video_id,
+    validate_youtube_url,
+)
 
 logger = logging.getLogger(__name__)
-
-YOUTUBE_METADATA_PROVIDER_YTDLP = "yt_dlp"
-YOUTUBE_METADATA_PROVIDER_DATA_API = "youtube_data_api"
-YOUTUBE_DATA_API_URL = "https://www.googleapis.com/youtube/v3/videos"
-
-
-class YouTubeDownloader:
-    """Enhanced YouTube downloader with optimized settings."""
-
-    def __init__(self):
-        self.temp_dir = Path(get_config().temp_dir)
-        self.temp_dir.mkdir(parents=True, exist_ok=True)
-
-    def get_optimal_download_options(
-        self,
-        video_id: str,
-    ) -> Dict[str, Any]:
-        """Get optimal yt-dlp options for high-quality downloads."""
-        output_path = self.temp_dir / f"{video_id}.%(ext)s"
-
-        opts = {
-            "outtmpl": str(output_path),
-            # Use best available video/audio to avoid quality caps from container constraints.
-            "format": "bestvideo*+bestaudio/best",
-            "format_sort": ["res", "fps"],
-            "merge_output_format": "mp4",
-            "writesubtitles": False,
-            "writeautomaticsub": False,
-            "noplaylist": True,
-            "overwrites": True,
-            # Optimized for speed and reliability
-            "socket_timeout": 30,
-            "retries": 5,  # Increased retries
-            "fragment_retries": 5,
-            "http_chunk_size": 10485760,  # 10MB chunks
-            # Quiet operation - only errors/warnings
-            "quiet": True,
-            "no_warnings": False,  # Show warnings but not info
-            "ignoreerrors": False,
-            # Enhanced headers to avoid 403 errors
-            "http_headers": {
-                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-                "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-                "Accept-Language": "en-US,en;q=0.9",
-                "Accept-Encoding": "gzip, deflate",
-                "Connection": "keep-alive",
-            },
-            # Metadata extraction
-            "extract_flat": False,
-            "writeinfojson": False,
-            # Additional bypass options
-            "nocheckcertificate": True,
-            "prefer_insecure": False,
-            "age_limit": None,
-        }
-
-        return opts
-
-
-def _build_info_options() -> Dict[str, Any]:
-    ydl_opts = {
-        "quiet": True,
-        "no_warnings": True,
-        "extractaudio": False,
-        "skip_download": True,
-        "socket_timeout": 30,
-        "http_headers": {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Accept-Language": "en-US,en;q=0.9",
-            "Connection": "keep-alive",
-        },
-        "nocheckcertificate": True,
-    }
-    return ydl_opts
-
-
-def _empty_video_info(video_id: Optional[str] = None) -> Dict[str, Any]:
-    return {
-        "id": video_id,
-        "title": None,
-        "description": "",
-        "duration": None,
-        "uploader": None,
-        "upload_date": None,
-        "view_count": None,
-        "like_count": None,
-        "thumbnail": None,
-        "format_id": None,
-        "resolution": None,
-        "fps": None,
-        "filesize": None,
-    }
-
-
-def _parse_iso8601_duration_to_seconds(value: str) -> int:
-    match = re.fullmatch(
-        r"P(?:(?P<days>\d+)D)?(?:T(?:(?P<hours>\d+)H)?(?:(?P<minutes>\d+)M)?(?:(?P<seconds>\d+)S)?)?",
-        value or "",
-    )
-    if not match:
-        raise ValueError(f"Unsupported ISO 8601 duration: {value}")
-
-    days = int(match.group("days") or 0)
-    hours = int(match.group("hours") or 0)
-    minutes = int(match.group("minutes") or 0)
-    seconds = int(match.group("seconds") or 0)
-    return (((days * 24) + hours) * 60 + minutes) * 60 + seconds
-
-
-def _pick_best_thumbnail(thumbnails: Optional[Dict[str, Any]]) -> Optional[str]:
-    if not thumbnails:
-        return None
-
-    for key in ("maxres", "standard", "high", "medium", "default"):
-        candidate = thumbnails.get(key)
-        if isinstance(candidate, dict) and candidate.get("url"):
-            return candidate["url"]
-
-    for candidate in thumbnails.values():
-        if isinstance(candidate, dict) and candidate.get("url"):
-            return candidate["url"]
-
-    return None
-
-
-def _normalize_upload_date(published_at: Optional[str]) -> Optional[str]:
-    if not published_at:
-        return None
-
-    try:
-        return (
-            datetime.fromisoformat(published_at.replace("Z", "+00:00"))
-            .strftime("%Y%m%d")
-        )
-    except ValueError:
-        logger.warning("Could not parse YouTube publishedAt value: %s", published_at)
-        return None
-
-
-def _parse_optional_int(value: Any) -> Optional[int]:
-    if value is None or value == "":
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _get_local_video_dimensions(path: Path) -> tuple[int, int]:
-    """Return local video width/height using ffprobe."""
-    try:
-        command = [
-            "ffprobe",
-            "-v",
-            "error",
-            "-select_streams",
-            "v:0",
-            "-show_entries",
-            "stream=width,height",
-            "-of",
-            "csv=s=x:p=0",
-            str(path),
-        ]
-        result = subprocess.run(command, capture_output=True, text=True, check=True)
-        output = result.stdout.strip()
-        if not output or "x" not in output:
-            return (0, 0)
-        width_str, height_str = output.split("x", 1)
-        return (int(width_str), int(height_str))
-    except Exception:
-        return (0, 0)
-
-
-def _remove_cached_downloads(temp_dir: Path, video_id: str) -> None:
-    cached_files = [
-        file_path
-        for file_path in temp_dir.glob(f"{video_id}.*")
-        if file_path.is_file()
-        and file_path.suffix.lower() in [".mp4", ".mkv", ".webm", ".mov", ".m4v"]
-    ]
-    if not cached_files:
-        return
-
-    logger.info(
-        "Refreshing download for %s (found %s cached file(s))",
-        video_id,
-        len(cached_files),
-    )
-    for cached_file in cached_files:
-        try:
-            cached_file.unlink()
-        except Exception as exc:
-            logger.warning("Failed to remove stale cache file %s: %s", cached_file, exc)
-
-
-def get_youtube_video_id(url: str) -> Optional[str]:
-    """
-    Extract YouTube video ID from various URL formats.
-    Supports standard, short, embed, and mobile URLs.
-    """
-    if not isinstance(url, str) or not url.strip():
-        return None
-
-    url = url.strip()
-
-    # Comprehensive regex patterns for different YouTube URL formats
-    patterns = [
-        r"(?:youtube\.com/(?:.*v=|v/|embed/|shorts/)|youtu\.be/)([A-Za-z0-9_-]{11})",
-        r"youtube\.com/watch\?v=([A-Za-z0-9_-]{11})",
-        r"youtube\.com/embed/([A-Za-z0-9_-]{11})",
-        r"youtube\.com/v/([A-Za-z0-9_-]{11})",
-        r"youtu\.be/([A-Za-z0-9_-]{11})",
-        r"youtube\.com/shorts/([A-Za-z0-9_-]{11})",
-        r"m\.youtube\.com/watch\?v=([A-Za-z0-9_-]{11})",
-    ]
-
-    for pattern in patterns:
-        match = re.search(pattern, url, re.IGNORECASE)
-        if match:
-            video_id = match.group(1)
-            # Validate video ID length (YouTube IDs are always 11 characters)
-            if len(video_id) == 11:
-                return video_id
-
-    # Fallback: parse query parameters
-    try:
-        parsed_url = urlparse(url)
-        if "youtube.com" in parsed_url.netloc.lower():
-            query = parse_qs(parsed_url.query)
-            video_ids = query.get("v")
-            if video_ids and len(video_ids[0]) == 11:
-                return video_ids[0]
-    except Exception as e:
-        logger.warning(f"Error parsing URL query parameters: {e}")
-
-    return None
-
-
-def validate_youtube_url(url: str) -> bool:
-    """Validate if URL is a proper YouTube URL."""
-    video_id = get_youtube_video_id(url)
-    return video_id is not None
 
 
 def _fetch_video_info_with_ytdlp(url: str) -> Dict[str, Any]:
@@ -346,9 +122,7 @@ def _fetch_video_info_with_youtube_data_api(url: str) -> Dict[str, Any]:
 
 
 def fetch_video_info(url: str) -> Optional[Dict[str, Any]]:
-    """
-    Backward-compatible metadata lookup entrypoint.
-    """
+    """Backward-compatible metadata lookup entrypoint."""
     return get_youtube_video_info(url)
 
 
@@ -423,13 +197,8 @@ def get_youtube_video_info(
     return None
 
 
-def get_youtube_video_title(
-    url: str,
-) -> Optional[str]:
-    """
-    Get the title of a YouTube video from a URL.
-    Enhanced with better error handling and validation.
-    """
+def get_youtube_video_title(url: str) -> Optional[str]:
+    """Get the title of a YouTube video from a URL."""
     video_info = get_youtube_video_info(url)
     return video_info.get("title") if video_info else None
 
@@ -464,10 +233,7 @@ def _download_youtube_video_with_ytdlp(
     max_retries: int = 3,
     task_id: Optional[str] = None,
 ) -> Optional[Path]:
-    """
-    Download YouTube video with optimized settings and retry logic.
-    Returns the path to the downloaded file, or None if download fails.
-    """
+    """Download YouTube video with optimized settings and retry logic."""
     logger.info(f"Starting YouTube download: {url}")
 
     video_id = get_youtube_video_id(url)
@@ -566,10 +332,7 @@ def download_youtube_video(
     max_retries: int = 3,
     task_id: Optional[str] = None,
 ) -> Optional[Path]:
-    """
-    Download YouTube video with Apify as the primary provider and yt-dlp fallback.
-    Returns the path to the downloaded file, or None if both providers fail.
-    """
+    """Download YouTube video with Apify primary + yt-dlp fallback."""
     logger.info("Starting YouTube download: %s", url)
 
     video_id = get_youtube_video_id(url)
@@ -626,24 +389,18 @@ def get_video_duration(url: str) -> Optional[int]:
 def is_video_suitable_for_processing(
     url: str, min_duration: int = 60, max_duration: int = 7200
 ) -> bool:
-    """
-    Check if video is suitable for processing based on duration and other factors.
-    Default limits: 1 minute to 2 hours.
-    """
+    """Check if video is suitable for processing based on duration."""
     video_info = get_youtube_video_info(url)
     if not video_info:
         return False
 
     duration = video_info.get("duration", 0)
 
-    # Check duration constraints
     if duration < min_duration or duration > max_duration:
         logger.warning(
             f"Video duration {duration}s outside allowed range ({min_duration}-{max_duration}s)"
         )
         return False
-
-    # Additional checks could go here (e.g., content type, quality, etc.)
 
     return True
 
@@ -661,7 +418,6 @@ def cleanup_downloaded_files(video_id: str):
             logger.warning(f"Failed to cleanup {file_path.name}: {e}")
 
 
-# Backward compatibility functions
 def extract_video_id(url: str) -> Optional[str]:
     """Backward compatibility wrapper."""
     return get_youtube_video_id(url)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -33,12 +33,13 @@ class FakeQueueAdapter:
         return None
 
     @classmethod
-    async def enqueue_processing_job(cls, function_name: str, processing_mode: str, *args):
+    async def enqueue_processing_job(cls, function_name: str, processing_mode: str, *args, **kwargs):
         cls.enqueued_jobs.append(
           {
             "function_name": function_name,
             "processing_mode": processing_mode,
             "args": args,
+            "kwargs": kwargs,
           }
         )
         return "job-test-1"

--- a/backend/tests/integration/test_clips_endpoints.py
+++ b/backend/tests/integration/test_clips_endpoints.py
@@ -1,0 +1,108 @@
+"""Integration tests for clip editing endpoints.
+
+Covers the 404/403/validation branches of ``/tasks/{id}/clips/*``. The full
+trim/split/merge paths require MoviePy ffmpeg invocations so are not asserted
+here — only the guard/validation layers are exercised.
+"""
+
+import pytest
+
+from tests.fixtures.factories import (
+    create_clip,
+    create_source,
+    create_task,
+    create_user,
+)
+
+
+@pytest.mark.asyncio
+async def test_delete_clip_returns_403_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="clip-owner", email="co@example.com")
+    other = await create_user(db_session, user_id="clip-other", email="cto@example.com")
+    source = await create_source(db_session, title="Guarded")
+    task = await create_task(
+        db_session, user_id=owner["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.delete(
+        f"/tasks/{task['id']}/clips/{clip['id']}",
+        headers={"x-supoclip-user-id": other["id"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_clip_returns_404_when_task_missing(client, db_session):
+    await create_user(db_session, user_id="ghost-clip", email="gc@example.com")
+
+    response = await client.delete(
+        "/tasks/no-task/clips/no-clip",
+        headers={"x-supoclip-user-id": "ghost-clip"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_trim_clip_rejects_negative_offsets(client, db_session):
+    user = await create_user(db_session, user_id="trimmer", email="tr@example.com")
+    source = await create_source(db_session, title="Trim source")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.patch(
+        f"/tasks/{task['id']}/clips/{clip['id']}",
+        headers={"x-supoclip-user-id": user["id"]},
+        json={"start_offset": -1, "end_offset": 0},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_split_clip_rejects_non_positive_time(client, db_session):
+    user = await create_user(db_session, user_id="splitter", email="sp@example.com")
+    source = await create_source(db_session, title="Split source")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.post(
+        f"/tasks/{task['id']}/clips/{clip['id']}/split",
+        headers={"x-supoclip-user-id": user["id"]},
+        json={"split_time": 0},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_clip_edit_endpoints_require_auth(client, db_session):
+    # Missing x-supoclip-user-id header should not reach the service layer
+    response = await client.patch(
+        "/tasks/any/clips/any",
+        json={"start_offset": 0, "end_offset": 0},
+    )
+    assert response.status_code in (401, 403)
+
+    response = await client.delete("/tasks/any/clips/any")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_trim_forbidden_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="t-owner", email="to@example.com")
+    other = await create_user(db_session, user_id="t-other", email="tot@example.com")
+    source = await create_source(db_session, title="Guarded trim")
+    task = await create_task(
+        db_session, user_id=owner["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.patch(
+        f"/tasks/{task['id']}/clips/{clip['id']}",
+        headers={"x-supoclip-user-id": other["id"]},
+        json={"start_offset": 0, "end_offset": 0},
+    )
+    assert response.status_code == 403

--- a/backend/tests/integration/test_clips_endpoints.py
+++ b/backend/tests/integration/test_clips_endpoints.py
@@ -57,7 +57,8 @@ async def test_trim_clip_rejects_negative_offsets(client, db_session):
         headers={"x-supoclip-user-id": user["id"]},
         json={"start_offset": -1, "end_offset": 0},
     )
-    assert response.status_code == 400
+    # Pydantic schema rejects with 422 (FastAPI validation error)
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio
@@ -74,7 +75,40 @@ async def test_split_clip_rejects_non_positive_time(client, db_session):
         headers={"x-supoclip-user-id": user["id"]},
         json={"split_time": 0},
     )
-    assert response.status_code == 400
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_merge_clips_rejects_too_few_ids(client, db_session):
+    user = await create_user(db_session, user_id="merger", email="mg@example.com")
+    source = await create_source(db_session, title="Merge")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+
+    response = await client.post(
+        f"/tasks/{task['id']}/clips/merge",
+        headers={"x-supoclip-user-id": user["id"]},
+        json={"clip_ids": ["one"]},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_captions_rejects_invalid_position(client, db_session):
+    user = await create_user(db_session, user_id="cap-user", email="cp@example.com")
+    source = await create_source(db_session, title="Captions")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.patch(
+        f"/tasks/{task['id']}/clips/{clip['id']}/captions",
+        headers={"x-supoclip-user-id": user["id"]},
+        json={"caption_text": "hi", "position": "nowhere"},
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_export_and_admin_endpoints.py
+++ b/backend/tests/integration/test_export_and_admin_endpoints.py
@@ -1,0 +1,114 @@
+"""Integration tests for export + admin task endpoints.
+
+Only guard-rails (auth, validation, not-found) are exercised — the actual
+video export calls ffmpeg/MoviePy which would make the test slow and flaky.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from tests.fixtures.factories import (
+    create_clip,
+    create_source,
+    create_task,
+    create_user,
+)
+
+
+@pytest.mark.asyncio
+async def test_export_rejects_unknown_preset(client, db_session):
+    user = await create_user(db_session, user_id="exp-user", email="exp@example.com")
+    source = await create_source(db_session, title="Export")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.get(
+        f"/tasks/{task['id']}/clips/{clip['id']}/export?preset=not-real",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_export_forbidden_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="exp-owner", email="eo@example.com")
+    other = await create_user(db_session, user_id="exp-other", email="eoo@example.com")
+    source = await create_source(db_session, title="Owned")
+    task = await create_task(
+        db_session, user_id=owner["id"], source_id=source["id"], status="completed"
+    )
+    clip = await create_clip(db_session, task_id=task["id"])
+
+    response = await client.get(
+        f"/tasks/{task['id']}/clips/{clip['id']}/export?preset=tiktok",
+        headers={"x-supoclip-user-id": other["id"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_export_requires_user_header(client, db_session):
+    response = await client.get("/tasks/any/clips/any/export?preset=tiktok")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_export_returns_404_when_task_missing(client, db_session):
+    await create_user(db_session, user_id="lonely", email="lonely@example.com")
+
+    response = await client.get(
+        "/tasks/no-task/clips/no-clip/export?preset=tiktok",
+        headers={"x-supoclip-user-id": "lonely"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_admin_metrics_reachable_in_self_host(client, db_session):
+    """Self-host deployments skip the admin check, so both roles can see metrics."""
+    await create_user(
+        db_session,
+        user_id="metrics-user",
+        email="mu@example.com",
+        is_admin=False,
+    )
+
+    response = await client.get(
+        "/tasks/metrics/performance",
+        headers={"x-supoclip-user-id": "metrics-user"},
+    )
+    assert response.status_code == 200
+    assert isinstance(response.json(), dict)
+
+
+@pytest.mark.asyncio
+async def test_admin_metrics_works_for_admin(client, db_session):
+    await create_user(
+        db_session,
+        user_id="admin-user",
+        email="admin@example.com",
+        is_admin=True,
+    )
+
+    response = await client.get(
+        "/tasks/metrics/performance",
+        headers={"x-supoclip-user-id": "admin-user"},
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_admin_dead_letter_list_shape(client, db_session):
+    await create_user(
+        db_session, user_id="dl-user", email="dl@example.com", is_admin=True
+    )
+
+    response = await client.get(
+        "/tasks/dead-letter/list",
+        headers={"x-supoclip-user-id": "dl-user"},
+    )
+    assert response.status_code == 200
+    # Endpoint returns a dict — shape is enforced by the handler, just verify type.
+    assert isinstance(response.json(), dict)

--- a/backend/tests/integration/test_lifecycle_endpoints.py
+++ b/backend/tests/integration/test_lifecycle_endpoints.py
@@ -1,0 +1,194 @@
+"""Integration tests for task lifecycle endpoints.
+
+Covers happy-path + 404 + 403 branches for GET /tasks/{id}, DELETE /tasks/{id},
+POST /tasks/{id}/cancel, and validation errors on POST /tasks/.
+"""
+
+import pytest
+
+from tests.fixtures.factories import (
+    create_clip,
+    create_source,
+    create_task,
+    create_user,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_task_returns_details_with_clips(client, db_session):
+    user = await create_user(db_session, user_id="owner-1", email="owner1@example.com")
+    source = await create_source(db_session, title="My source")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    await create_clip(db_session, task_id=task["id"], text_value="first clip")
+
+    response = await client.get(
+        f"/tasks/{task['id']}",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == task["id"]
+    assert payload["clips_count"] == 1
+    assert payload["clips"][0]["text"] == "first clip"
+
+
+@pytest.mark.asyncio
+async def test_get_task_returns_404_when_missing(client, db_session):
+    await create_user(db_session, user_id="nobody", email="nobody@example.com")
+
+    response = await client.get(
+        "/tasks/does-not-exist",
+        headers={"x-supoclip-user-id": "nobody"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_task_forbidden_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="owner-x", email="ox@example.com")
+    other = await create_user(db_session, user_id="other-x", email="otx@example.com")
+    source = await create_source(db_session, title="Guarded")
+    task = await create_task(db_session, user_id=owner["id"], source_id=source["id"])
+
+    response = await client.get(
+        f"/tasks/{task['id']}",
+        headers={"x-supoclip-user-id": other["id"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_task_success(client, db_session):
+    user = await create_user(db_session, user_id="deleter", email="del@example.com")
+    source = await create_source(db_session, title="To delete")
+    task = await create_task(db_session, user_id=user["id"], source_id=source["id"])
+
+    response = await client.delete(
+        f"/tasks/{task['id']}",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert response.status_code == 200
+
+    # Second GET confirms gone (404)
+    followup = await client.get(
+        f"/tasks/{task['id']}",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert followup.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_task_returns_403_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="d-owner", email="do@example.com")
+    other = await create_user(db_session, user_id="d-other", email="doo@example.com")
+    source = await create_source(db_session, title="Protected")
+    task = await create_task(db_session, user_id=owner["id"], source_id=source["id"])
+
+    response = await client.delete(
+        f"/tasks/{task['id']}",
+        headers={"x-supoclip-user-id": other["id"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_delete_task_returns_404_when_missing(client, db_session):
+    await create_user(db_session, user_id="ghost", email="ghost@example.com")
+
+    response = await client.delete(
+        "/tasks/ghost-id",
+        headers={"x-supoclip-user-id": "ghost"},
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_task_clips_endpoint(client, db_session):
+    user = await create_user(db_session, user_id="clipper", email="c@example.com")
+    source = await create_source(db_session, title="Clipped")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+    await create_clip(db_session, task_id=task["id"], text_value="a")
+    await create_clip(db_session, task_id=task["id"], text_value="b")
+
+    response = await client.get(
+        f"/tasks/{task['id']}/clips",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["task_id"] == task["id"]
+    assert payload["total_clips"] == 2
+    assert sorted(c["text"] for c in payload["clips"]) == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_acknowledged_when_already_terminal(client, db_session):
+    user = await create_user(db_session, user_id="canceller", email="cx@example.com")
+    source = await create_source(db_session, title="Done already")
+    task = await create_task(
+        db_session, user_id=user["id"], source_id=source["id"], status="completed"
+    )
+
+    response = await client.post(
+        f"/tasks/{task['id']}/cancel",
+        headers={"x-supoclip-user-id": user["id"]},
+    )
+    assert response.status_code == 200
+    assert "already" in response.json()["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_forbidden_for_other_user(client, db_session):
+    owner = await create_user(db_session, user_id="c-owner", email="co@example.com")
+    other = await create_user(db_session, user_id="c-other", email="coo@example.com")
+    source = await create_source(db_session, title="Running")
+    task = await create_task(
+        db_session, user_id=owner["id"], source_id=source["id"], status="processing"
+    )
+
+    response = await client.post(
+        f"/tasks/{task['id']}/cancel",
+        headers={"x-supoclip-user-id": other["id"]},
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_create_task_requires_user_header(client, db_session):
+    response = await client.post(
+        "/tasks/",
+        json={"source": {"url": "https://www.youtube.com/watch?v=demo"}},
+    )
+    # No x-supoclip-user-id header → 401/403 depending on auth impl
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_missing_source(client, db_session):
+    await create_user(db_session, user_id="u-missing", email="um@example.com")
+
+    response = await client.post(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "u-missing"},
+        json={},
+    )
+    # missing source should be a 4xx
+    assert 400 <= response.status_code < 500
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_empty_for_new_user(client, db_session):
+    await create_user(db_session, user_id="fresh-user", email="fresh@example.com")
+
+    response = await client.get(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "fresh-user"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["total"] == 0
+    assert payload["tasks"] == []

--- a/backend/tests/integration/test_lifecycle_endpoints.py
+++ b/backend/tests/integration/test_lifecycle_endpoints.py
@@ -192,3 +192,77 @@ async def test_list_tasks_empty_for_new_user(client, db_session):
     payload = response.json()
     assert payload["total"] == 0
     assert payload["tasks"] == []
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_invalid_font_color(client, db_session):
+    await create_user(db_session, user_id="styler", email="st@example.com")
+
+    response = await client.post(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "styler"},
+        json={
+            "source": {"url": "https://www.youtube.com/watch?v=demo"},
+            "font_options": {"font_color": "not-a-hex"},
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_oversized_font(client, db_session):
+    await create_user(db_session, user_id="big-font", email="bf@example.com")
+
+    response = await client.post(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "big-font"},
+        json={
+            "source": {"url": "https://www.youtube.com/watch?v=demo"},
+            "font_options": {"font_size": 999},
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_unknown_processing_mode(client, db_session):
+    await create_user(db_session, user_id="mode-user", email="mm@example.com")
+
+    response = await client.post(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "mode-user"},
+        json={
+            "source": {"url": "https://www.youtube.com/watch?v=demo"},
+            "processing_mode": "ultra-extra-hd",
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_unknown_output_format(client, db_session):
+    await create_user(db_session, user_id="fmt-user", email="fm@example.com")
+
+    response = await client.post(
+        "/tasks/",
+        headers={"x-supoclip-user-id": "fmt-user"},
+        json={
+            "source": {"url": "https://www.youtube.com/watch?v=demo"},
+            "output_format": "cinematic-4k",
+        },
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_task_settings_rejects_bad_color(client, db_session):
+    user = await create_user(db_session, user_id="set-user", email="sx@example.com")
+    source = await create_source(db_session, title="Settings")
+    task = await create_task(db_session, user_id=user["id"], source_id=source["id"])
+
+    response = await client.post(
+        f"/tasks/{task['id']}/settings",
+        headers={"x-supoclip-user-id": user["id"]},
+        json={"font_color": "rgb(1,2,3)"},
+    )
+    assert response.status_code == 422

--- a/backend/tests/unit/test_ai_config_errors.py
+++ b/backend/tests/unit/test_ai_config_errors.py
@@ -1,0 +1,143 @@
+"""Tests for ``src/ai.py`` config-error helper and prompt builder."""
+
+import pytest
+
+from src import ai as ai_module
+from src.ai import (
+    BRollOpportunity,
+    TranscriptAnalysis,
+    TranscriptSegment,
+    ViralityAnalysis,
+    _get_missing_llm_key_error,
+    build_transcript_analysis_prompt,
+)
+from src.ai_prompt_defaults import BROLL_INSTRUCTION_SUFFIX, TRANSCRIPT_USER_TEMPLATE_DEFAULT
+
+
+class TestGetMissingLlmKeyError:
+    def test_google_without_key(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "google_api_key", None)
+        err = _get_missing_llm_key_error("google-gla:gemini-3-flash-preview")
+        assert err is not None
+        assert "GOOGLE_API_KEY" in err
+
+    def test_google_alias(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "google_api_key", None)
+        assert _get_missing_llm_key_error("google:gemini-2.5-pro") is not None
+
+    def test_google_with_key_ok(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "google_api_key", "present")
+        assert _get_missing_llm_key_error("google-gla:gemini-2.5-pro") is None
+
+    def test_openai_without_key(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "openai_api_key", None)
+        err = _get_missing_llm_key_error("openai:gpt-4o-mini")
+        assert err is not None
+        assert "OPENAI_API_KEY" in err
+
+    def test_openai_with_key_ok(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "openai_api_key", "present")
+        assert _get_missing_llm_key_error("openai:gpt-4o-mini") is None
+
+    def test_anthropic_without_key(self, monkeypatch):
+        monkeypatch.setattr(ai_module.config, "anthropic_api_key", None)
+        err = _get_missing_llm_key_error("anthropic:claude-sonnet-4-5")
+        assert err is not None
+        assert "ANTHROPIC_API_KEY" in err
+
+    def test_ollama_no_key_is_fine(self):
+        assert _get_missing_llm_key_error("ollama:llama3.2") is None
+
+    def test_unknown_provider_silently_allowed(self):
+        assert _get_missing_llm_key_error("unknownprovider:model") is None
+
+
+class TestBuildTranscriptAnalysisPrompt:
+    def test_basic_substitution(self):
+        result = build_transcript_analysis_prompt("00:00 hello world", include_broll=False)
+        assert "00:00 hello world" in result
+        # With no broll, the broll instruction suffix must NOT be there
+        assert BROLL_INSTRUCTION_SUFFIX not in result
+
+    def test_broll_appended(self):
+        result = build_transcript_analysis_prompt("t", include_broll=True)
+        assert BROLL_INSTRUCTION_SUFFIX in result
+
+    def test_custom_template(self):
+        template = "TRANSCRIPT={transcript}|BROLL={broll_instruction}"
+        result = build_transcript_analysis_prompt(
+            "abc", include_broll=False, template=template
+        )
+        assert result == "TRANSCRIPT=abc|BROLL="
+
+    def test_custom_template_with_broll(self):
+        template = "T:{transcript}\nB:{broll_instruction}"
+        result = build_transcript_analysis_prompt(
+            "doc", include_broll=True, template=template
+        )
+        assert "T:doc" in result
+        assert BROLL_INSTRUCTION_SUFFIX in result
+
+
+class TestPydanticModels:
+    def test_virality_analysis_valid(self):
+        va = ViralityAnalysis(
+            hook_score=10,
+            engagement_score=15,
+            value_score=20,
+            shareability_score=5,
+            total_score=50,
+            hook_type="question",
+            virality_reasoning="ok",
+        )
+        assert va.total_score == 50
+
+    @pytest.mark.parametrize("field,value", [
+        ("hook_score", -1),
+        ("hook_score", 26),
+        ("engagement_score", 26),
+        ("total_score", 101),
+    ])
+    def test_virality_rejects_out_of_range(self, field, value):
+        data = dict(
+            hook_score=10,
+            engagement_score=10,
+            value_score=10,
+            shareability_score=10,
+            total_score=40,
+            virality_reasoning="ok",
+        )
+        data[field] = value
+        with pytest.raises(Exception):
+            ViralityAnalysis(**data)
+
+    def test_transcript_segment_valid(self):
+        seg = TranscriptSegment(
+            start_time="00:05",
+            end_time="00:20",
+            text="hello",
+            relevance_score=0.8,
+            reasoning="r",
+            virality=ViralityAnalysis(
+                hook_score=5, engagement_score=5, value_score=5, shareability_score=5,
+                total_score=20, virality_reasoning="ok",
+            ),
+        )
+        assert seg.start_time == "00:05"
+        assert seg.relevance_score == 0.8
+
+    def test_broll_opportunity_rejects_duration_bounds(self):
+        # Duration ge=2.0 le=5.0
+        with pytest.raises(Exception):
+            BRollOpportunity(timestamp="00:05", duration=1.5, search_term="x", context="y")
+        with pytest.raises(Exception):
+            BRollOpportunity(timestamp="00:05", duration=6.0, search_term="x", context="y")
+
+    def test_transcript_analysis_allows_empty_broll(self):
+        analysis = TranscriptAnalysis(
+            most_relevant_segments=[],
+            summary="s",
+            key_topics=["a"],
+            broll_opportunities=None,
+        )
+        assert analysis.broll_opportunities is None

--- a/backend/tests/unit/test_apify_helpers.py
+++ b/backend/tests/unit/test_apify_helpers.py
@@ -1,0 +1,93 @@
+"""Tests for pure helpers in ``src/apify_youtube_downloader.py``.
+
+Focuses on the recursive URL extractor + file-extension inference — the
+``download_video_via_apify`` entry point itself is already covered by
+``tests/unit/test_apify_youtube_downloader.py``.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.apify_youtube_downloader import (
+    ALLOWED_APIFY_QUALITIES,
+    _extract_download_url,
+    _infer_file_extension,
+    normalize_apify_quality,
+)
+
+
+class TestNormalizeApifyQuality:
+    @pytest.mark.parametrize("value", sorted(ALLOWED_APIFY_QUALITIES))
+    def test_valid(self, value):
+        assert normalize_apify_quality(value) == value
+
+    def test_trims_whitespace(self):
+        assert normalize_apify_quality("  720  ") == "720"
+
+    @pytest.mark.parametrize("value", [None, "", "4k", "2160", "garbage"])
+    def test_invalid_fallback(self, value):
+        assert normalize_apify_quality(value) == "1080"
+
+
+class TestExtractDownloadUrl:
+    def test_direct_download_url_field(self):
+        assert _extract_download_url({"downloadUrl": "https://x.com/a.mp4"}) == "https://x.com/a.mp4"
+
+    def test_non_http_direct_ignored(self):
+        # downloadUrl that's not http(s) → keeps looking
+        assert _extract_download_url({"downloadUrl": "ftp://x.com/a.mp4"}) is None
+
+    def test_any_download_flavored_key(self):
+        assert _extract_download_url({"video_download_link": "https://x.com/a"}) == "https://x.com/a"
+
+    def test_nested_dict(self):
+        payload = {"result": {"nested": {"downloadUrl": "https://y/z.mp4"}}}
+        assert _extract_download_url(payload) == "https://y/z.mp4"
+
+    def test_list_of_items(self):
+        payload = [
+            {"noop": 1},
+            {"downloadUrl": "https://pick.me/v.mp4"},
+        ]
+        assert _extract_download_url(payload) == "https://pick.me/v.mp4"
+
+    def test_none_returned_for_empty(self):
+        assert _extract_download_url({}) is None
+        assert _extract_download_url([]) is None
+        assert _extract_download_url(None) is None
+        assert _extract_download_url("scalar") is None
+
+
+class TestInferFileExtension:
+    def _response(self, headers):
+        resp = MagicMock()
+        resp.headers = headers
+        return resp
+
+    def test_content_disposition_filename(self):
+        resp = self._response({"Content-Disposition": 'attachment; filename="video.mkv"'})
+        assert _infer_file_extension(resp, "https://x/y") == ".mkv"
+
+    def test_content_disposition_utf8_filename(self):
+        resp = self._response({"Content-Disposition": "attachment; filename*=UTF-8''my%20clip.webm"})
+        assert _infer_file_extension(resp, "https://x/y") == ".webm"
+
+    def test_content_type_fallback(self):
+        resp = self._response({"Content-Type": "video/mp4"})
+        ext = _infer_file_extension(resp, "https://x/y")
+        assert ext == ".mp4"
+
+    def test_url_path_suffix_fallback(self):
+        resp = self._response({})
+        assert _infer_file_extension(resp, "https://x/path/video.avi?token=123") == ".avi"
+
+    def test_default_mp4_when_unknown(self):
+        resp = self._response({})
+        assert _infer_file_extension(resp, "https://x/unknown-endpoint") == ".mp4"
+
+    def test_content_type_with_parameters(self):
+        # "video/mp4; codecs=avc1" → ignores parameters, uses "video/mp4"
+        resp = self._response({"Content-Type": "video/mp4; codecs=avc1"})
+        assert _infer_file_extension(resp, "https://x/y") == ".mp4"

--- a/backend/tests/unit/test_async_helpers.py
+++ b/backend/tests/unit/test_async_helpers.py
@@ -1,0 +1,55 @@
+"""Tests for ``src/utils/async_helpers.py``."""
+
+import pytest
+
+from src.utils.async_helpers import async_wrap, run_in_thread
+
+
+class TestRunInThread:
+    @pytest.mark.asyncio
+    async def test_returns_function_result(self):
+        result = await run_in_thread(lambda x, y: x + y, 2, 3)
+        assert result == 5
+
+    @pytest.mark.asyncio
+    async def test_accepts_kwargs(self):
+        def fn(a, *, b):
+            return a * b
+
+        result = await run_in_thread(fn, 3, b=4)
+        assert result == 12
+
+    @pytest.mark.asyncio
+    async def test_propagates_exceptions(self):
+        def fn():
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            await run_in_thread(fn)
+
+
+class TestAsyncWrap:
+    @pytest.mark.asyncio
+    async def test_wraps_sync_function(self):
+        @async_wrap
+        def add(a, b):
+            return a + b
+
+        assert await add(1, 2) == 3
+
+    @pytest.mark.asyncio
+    async def test_preserves_name(self):
+        @async_wrap
+        def greet():
+            return "hi"
+
+        assert greet.__name__ == "greet"
+
+    @pytest.mark.asyncio
+    async def test_propagates_exceptions(self):
+        @async_wrap
+        def failing():
+            raise RuntimeError("nope")
+
+        with pytest.raises(RuntimeError, match="nope"):
+            await failing()

--- a/backend/tests/unit/test_broll.py
+++ b/backend/tests/unit/test_broll.py
@@ -1,0 +1,155 @@
+"""Tests for ``src/broll.py`` pure helpers + model validation.
+
+The Pexels HTTP calls are mocked — only the pure resolution logic and
+Pydantic input guards are under test here.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.broll import BRollSuggestion, BRollVideo, get_video_download_url
+
+
+class TestGetVideoDownloadUrl:
+    def test_prefers_portrait_hd_match(self):
+        video = {
+            "video_files": [
+                {"quality": "hd", "width": 1920, "height": 1080, "link": "landscape_hd"},
+                {"quality": "hd", "width": 1080, "height": 1920, "link": "portrait_hd"},
+            ]
+        }
+        assert get_video_download_url(video, quality="hd", orientation="portrait") == "portrait_hd"
+
+    def test_landscape_match(self):
+        video = {
+            "video_files": [
+                {"quality": "hd", "width": 1080, "height": 1920, "link": "portrait"},
+                {"quality": "hd", "width": 1920, "height": 1080, "link": "landscape"},
+            ]
+        }
+        assert (
+            get_video_download_url(video, quality="hd", orientation="landscape")
+            == "landscape"
+        )
+
+    def test_falls_back_to_any_matching_quality(self):
+        # No orientation match — falls back to first matching-quality link.
+        video = {
+            "video_files": [
+                {"quality": "hd", "width": 1080, "height": 1920, "link": "p1"},
+                {"quality": "hd", "width": 720, "height": 1280, "link": "p2"},
+            ]
+        }
+        url = get_video_download_url(video, quality="hd", orientation="landscape")
+        assert url in ("p1", "p2")
+
+    def test_last_resort_returns_first_file(self):
+        # No quality match — uses the very first entry.
+        video = {
+            "video_files": [
+                {"quality": "sd", "width": 540, "height": 960, "link": "sd1"},
+            ]
+        }
+        assert get_video_download_url(video, quality="hd") == "sd1"
+
+    def test_empty_files_returns_none(self):
+        assert get_video_download_url({"video_files": []}) is None
+
+    def test_missing_files_key_returns_none(self):
+        assert get_video_download_url({}) is None
+
+
+class TestBRollVideoModel:
+    def test_valid_construction(self):
+        video = BRollVideo(
+            id=1,
+            width=1080,
+            height=1920,
+            duration=10,
+            url="https://pexels.com/v/1",
+            image="https://pexels.com/thumb/1.jpg",
+            video_files=[{"link": "a", "quality": "hd"}],
+            user={"name": "Someone"},
+        )
+        assert video.id == 1
+        assert video.duration == 10
+        assert video.video_files[0]["link"] == "a"
+
+    def test_missing_required_field(self):
+        with pytest.raises(Exception):
+            BRollVideo(
+                id=1,
+                width=1080,
+                height=1920,
+                duration=10,
+                url="https://pexels.com/v/1",
+                image="https://pexels.com/thumb/1.jpg",
+                video_files=[],
+                # user missing
+            )
+
+
+class TestBRollSuggestionModel:
+    def test_valid_short_suggestion(self):
+        sugg = BRollSuggestion(
+            keyword="sunset",
+            timestamp=5.0,
+            duration=3.0,
+            context="discussing weather",
+        )
+        assert sugg.keyword == "sunset"
+        assert sugg.video_url is None
+        assert sugg.local_path is None
+
+    @pytest.mark.parametrize("duration", [1.0, 1.99, 5.01, 10.0])
+    def test_duration_out_of_range(self, duration):
+        with pytest.raises(Exception):
+            BRollSuggestion(
+                keyword="sunset",
+                timestamp=5.0,
+                duration=duration,
+                context="context",
+            )
+
+    @pytest.mark.parametrize("duration", [2.0, 3.5, 5.0])
+    def test_duration_at_boundaries(self, duration):
+        sugg = BRollSuggestion(
+            keyword="sunset",
+            timestamp=0.0,
+            duration=duration,
+            context="context",
+        )
+        assert sugg.duration == duration
+
+
+@pytest.mark.asyncio
+class TestSearchBrollVideosHttpHandling:
+    async def test_returns_empty_when_no_api_key(self, monkeypatch):
+        from src import broll as broll_module
+
+        monkeypatch.setattr(broll_module.config, "pexels_api_key", None)
+        result = await broll_module.search_broll_videos("cats")
+        assert result == []
+
+    async def test_http_error_returns_empty(self, monkeypatch):
+        from src import broll as broll_module
+
+        monkeypatch.setattr(broll_module.config, "pexels_api_key", "fake-key")
+
+        class FakeAsyncClient:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def get(self, *args, **kwargs):
+                raise RuntimeError("network down")
+
+        monkeypatch.setattr(broll_module.httpx, "AsyncClient", FakeAsyncClient)
+        result = await broll_module.search_broll_videos("cats")
+        assert result == []

--- a/backend/tests/unit/test_capcut_export_builders.py
+++ b/backend/tests/unit/test_capcut_export_builders.py
@@ -1,0 +1,163 @@
+"""Tests for the CapCut draft JSON builders in ``src/capcut_export.py``.
+
+These cover the real ``build_draft_content`` / ``build_draft_meta_info`` flows
+using the on-disk JSON templates — only the ``package_capcut_draft`` zip/file IO
+path is skipped.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src.capcut_export import (
+    ClipExportInput,
+    SubtitleSegment,
+    _build_canvas_material,
+    _build_sound_channel_material,
+    _build_speed_material,
+    _build_text_material,
+    _build_text_segment,
+    _build_video_material,
+    _build_video_segment,
+    build_draft_content,
+    build_draft_meta_info,
+)
+
+
+def _clip(
+    *,
+    duration=10.0,
+    subtitle_segments=None,
+    caption_text=None,
+    project_name=None,
+):
+    return ClipExportInput(
+        clip_filename="clip_demo.mp4",
+        clip_source_path=Path("/tmp/clip_demo.mp4"),
+        duration_seconds=duration,
+        caption_text=caption_text,
+        subtitle_segments=subtitle_segments or [],
+        project_name=project_name,
+    )
+
+
+class TestBuildMaterials:
+    def test_video_material_has_path_and_type(self):
+        clip = _clip()
+        mat = _build_video_material("mat-1", clip, "Resources/clip_demo.mp4")
+        assert mat["id"] == "mat-1"
+        assert mat["path"] == "Resources/clip_demo.mp4"
+        assert mat["type"] == "video"
+        assert mat["duration"] == 10 * 1_000_000
+
+    def test_speed_material(self):
+        s = _build_speed_material("spd-1")
+        assert s["id"] == "spd-1"
+        assert s["type"] == "speed"
+        assert s["speed"] == 1.0
+
+    def test_canvas_material(self):
+        c = _build_canvas_material("cv-1")
+        assert c["id"] == "cv-1"
+        assert c["type"] == "canvas_color"
+
+    def test_sound_channel_material(self):
+        s = _build_sound_channel_material("sc-1")
+        assert s["id"] == "sc-1"
+        assert s["type"] == "none"
+
+    def test_text_material_wraps_content(self):
+        t = _build_text_material("t-1", "Hello <world>")
+        assert t["id"] == "t-1"
+        assert t["type"] == "text"
+        # content field embeds the string
+        assert "Hello <world>" in t["content"]
+
+
+class TestBuildSegments:
+    def test_video_segment_applies_extra_refs(self):
+        seg = _build_video_segment("seg-1", "mat-1", 5_000_000, ["spd", "cv", "sc"])
+        assert seg["id"] == "seg-1"
+        assert seg["material_id"] == "mat-1"
+        assert seg["target_timerange"]["duration"] == 5_000_000
+        # extra_material_refs must contain all three we passed
+        assert set(seg["extra_material_refs"]) == {"spd", "cv", "sc"}
+
+    def test_text_segment_default_start_zero(self):
+        seg = _build_text_segment("seg-t1", "mat-t1", 3_000_000)
+        assert seg["target_timerange"]["start"] == 0
+        assert seg["target_timerange"]["duration"] == 3_000_000
+
+    def test_text_segment_with_start_offset(self):
+        seg = _build_text_segment("seg-t2", "mat-t2", 2_500_000, 7_000_000)
+        assert seg["target_timerange"]["start"] == 7_000_000
+
+
+class TestBuildDraftContent:
+    def test_bare_clip_has_video_track(self):
+        draft = build_draft_content(_clip(duration=30.0))
+        assert draft["duration"] == 30 * 1_000_000
+        assert draft["canvas_config"] == {"width": 1080, "height": 1920, "ratio": "original"}
+        # A video track is always present with exactly one segment
+        video_tracks = [t for t in draft["tracks"] if t["type"] == "video"]
+        assert len(video_tracks) == 1
+        assert len(video_tracks[0]["segments"]) == 1
+
+    def test_name_falls_back_to_filename(self):
+        draft = build_draft_content(_clip(project_name=None))
+        assert draft["name"] == "clip_demo.mp4"
+
+    def test_project_name_overrides_filename(self):
+        draft = build_draft_content(_clip(project_name="My Cool Project"))
+        assert draft["name"] == "My Cool Project"
+
+    def test_legacy_single_caption_creates_text_track(self):
+        draft = build_draft_content(_clip(caption_text="Static caption"))
+        text_tracks = [t for t in draft["tracks"] if t["type"] == "text"]
+        assert len(text_tracks) == 1
+        # Exactly one text segment, spanning the full clip
+        segments = text_tracks[0]["segments"]
+        assert len(segments) == 1
+        assert segments[0]["target_timerange"]["start"] == 0
+
+    def test_subtitle_segments_become_text_track(self):
+        subs = [
+            SubtitleSegment(text="line one", start_seconds=0.0, end_seconds=1.0),
+            SubtitleSegment(text="line two", start_seconds=1.0, end_seconds=2.0),
+        ]
+        draft = build_draft_content(_clip(duration=3.0, subtitle_segments=subs))
+        text_tracks = [t for t in draft["tracks"] if t["type"] == "text"]
+        assert len(text_tracks) == 1
+        assert len(text_tracks[0]["segments"]) == 2
+        # Each subtitle produced exactly one text material
+        assert len(draft["materials"]["texts"]) == 2
+
+    def test_blank_subtitle_segments_skipped(self):
+        subs = [
+            SubtitleSegment(text="", start_seconds=0.0, end_seconds=1.0),
+            SubtitleSegment(text="   ", start_seconds=1.0, end_seconds=2.0),
+        ]
+        draft = build_draft_content(_clip(subtitle_segments=subs))
+        text_tracks = [t for t in draft["tracks"] if t["type"] == "text"]
+        # All segments blank → no text track at all
+        assert text_tracks == []
+
+    def test_subtitle_with_zero_duration_gets_minimum_100ms(self):
+        # start == end → builder enforces a floor duration
+        subs = [SubtitleSegment(text="same ts", start_seconds=5.0, end_seconds=5.0)]
+        draft = build_draft_content(_clip(subtitle_segments=subs))
+        seg = draft["tracks"][-1]["segments"][0]
+        assert seg["target_timerange"]["duration"] >= 100_000
+
+
+class TestBuildDraftMetaInfo:
+    def test_meta_fields(self):
+        meta = build_draft_meta_info(
+            project_id="proj-abc", project_name="My Draft", duration_seconds=15.0
+        )
+        # draft_id is upper-cased
+        assert meta["draft_id"] == "PROJ-ABC"
+        assert meta["draft_name"] == "My Draft"
+        assert meta["tm_duration"] == 15_000_000
+        assert meta["tm_draft_create"] > 0
+        assert meta["tm_draft_modified"] == meta["tm_draft_create"]

--- a/backend/tests/unit/test_capcut_export_helpers.py
+++ b/backend/tests/unit/test_capcut_export_helpers.py
@@ -1,0 +1,118 @@
+"""Tests for pure helpers in ``src/capcut_export.py``."""
+
+import uuid
+
+import pytest
+
+from src.capcut_export import (
+    ClipExportInput,
+    SubtitleSegment,
+    _default_clip_transform,
+    _default_crop,
+    _seconds_to_us,
+    _uuid_lower,
+    _uuid_upper,
+)
+
+
+class TestSecondsToUs:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, 0),
+            (0.5, 500_000),
+            (1, 1_000_000),
+            (1.5, 1_500_000),
+            (60, 60_000_000),
+        ],
+    )
+    def test_converts_to_microseconds(self, seconds, expected):
+        assert _seconds_to_us(seconds) == expected
+
+    def test_negative_clamps_to_zero(self):
+        assert _seconds_to_us(-5) == 0
+
+    def test_rounds_half_to_nearest(self):
+        # 0.0000005 seconds = 0.5 us → rounds to 1 (banker's rounds to 0 in py3)
+        assert _seconds_to_us(0.0000015) in (1, 2)
+
+
+class TestUuidHelpers:
+    def test_upper_is_valid_uuid_upper(self):
+        value = _uuid_upper()
+        assert value == value.upper()
+        assert uuid.UUID(value)  # raises if not a valid UUID
+
+    def test_lower_is_valid_uuid_lower(self):
+        value = _uuid_lower()
+        assert value == value.lower()
+        assert uuid.UUID(value)
+
+    def test_unique(self):
+        assert _uuid_upper() != _uuid_upper()
+        assert _uuid_lower() != _uuid_lower()
+
+
+class TestDefaultCrop:
+    def test_full_frame(self):
+        crop = _default_crop()
+        # Full frame: LL=(0,1), LR=(1,1), UL=(0,0), UR=(1,0)
+        assert crop["lower_left_x"] == 0.0
+        assert crop["lower_left_y"] == 1.0
+        assert crop["upper_right_x"] == 1.0
+        assert crop["upper_right_y"] == 0.0
+
+    def test_has_all_corners(self):
+        crop = _default_crop()
+        for corner in ("lower_left", "lower_right", "upper_left", "upper_right"):
+            assert f"{corner}_x" in crop
+            assert f"{corner}_y" in crop
+
+
+class TestDefaultClipTransform:
+    def test_identity_transform(self):
+        transform = _default_clip_transform()
+        assert transform["alpha"] == 1.0
+        assert transform["rotation"] == 0.0
+        assert transform["flip"] == {"horizontal": False, "vertical": False}
+
+
+class TestSubtitleSegment:
+    def test_fields(self):
+        seg = SubtitleSegment(text="hello", start_seconds=1.0, end_seconds=2.5)
+        assert seg.text == "hello"
+        assert seg.start_seconds == 1.0
+        assert seg.end_seconds == 2.5
+
+
+class TestClipExportInput:
+    def test_defaults(self):
+        from pathlib import Path
+
+        inp = ClipExportInput(
+            clip_filename="clip.mp4",
+            clip_source_path=Path("/tmp/clip.mp4"),
+            duration_seconds=15.0,
+        )
+        assert inp.width == 1080
+        assert inp.height == 1920
+        assert inp.caption_text is None
+        assert inp.subtitle_segments == []
+        assert inp.srt_content is None
+        assert inp.project_name is None
+
+    def test_accepts_subtitle_list(self):
+        from pathlib import Path
+
+        segments = [
+            SubtitleSegment("one", 0.0, 1.0),
+            SubtitleSegment("two", 1.0, 2.0),
+        ]
+        inp = ClipExportInput(
+            clip_filename="clip.mp4",
+            clip_source_path=Path("/tmp/clip.mp4"),
+            duration_seconds=2.0,
+            subtitle_segments=segments,
+        )
+        assert len(inp.subtitle_segments) == 2
+        assert inp.subtitle_segments[0].text == "one"

--- a/backend/tests/unit/test_caption_templates.py
+++ b/backend/tests/unit/test_caption_templates.py
@@ -1,0 +1,70 @@
+"""Tests for caption template lookups."""
+
+import pytest
+
+from src.caption_templates import (
+    CAPTION_TEMPLATES,
+    get_all_templates,
+    get_template,
+    get_template_info,
+    get_template_names,
+)
+
+
+REQUIRED_KEYS = {
+    "name",
+    "description",
+    "font_family",
+    "font_size",
+    "font_color",
+    "highlight_color",
+    "stroke_color",
+    "stroke_width",
+    "background",
+    "background_color",
+    "animation",
+    "shadow",
+    "position_y",
+}
+
+
+class TestGetTemplate:
+    @pytest.mark.parametrize("name", list(CAPTION_TEMPLATES.keys()))
+    def test_returns_template_by_name(self, name):
+        template = get_template(name)
+        assert template is CAPTION_TEMPLATES[name]
+
+    def test_unknown_returns_default(self):
+        assert get_template("does-not-exist") is CAPTION_TEMPLATES["default"]
+
+    def test_all_templates_have_required_keys(self):
+        for name, template in CAPTION_TEMPLATES.items():
+            missing = REQUIRED_KEYS - set(template.keys())
+            assert not missing, f"{name} missing keys: {missing}"
+
+    def test_animation_is_valid(self):
+        valid = {"none", "karaoke", "pop", "fade", "bounce"}
+        for name, template in CAPTION_TEMPLATES.items():
+            assert template["animation"] in valid, f"{name} has bad animation"
+
+    def test_position_y_within_bounds(self):
+        for name, template in CAPTION_TEMPLATES.items():
+            assert 0.0 <= template["position_y"] <= 1.0, f"{name} position_y out of range"
+
+
+class TestBulkAccessors:
+    def test_get_all_templates_returns_mapping(self):
+        assert get_all_templates() is CAPTION_TEMPLATES
+
+    def test_get_template_names(self):
+        names = get_template_names()
+        assert set(names) == set(CAPTION_TEMPLATES.keys())
+
+    def test_get_template_info_shape(self):
+        info = get_template_info()
+        assert len(info) == len(CAPTION_TEMPLATES)
+        info_keys = {"id", "name", "description", "animation", "font_family",
+                     "font_size", "font_color", "highlight_color"}
+        for entry in info:
+            assert set(entry.keys()) == info_keys
+            assert entry["id"] in CAPTION_TEMPLATES

--- a/backend/tests/unit/test_clip_editor_helpers.py
+++ b/backend/tests/unit/test_clip_editor_helpers.py
@@ -1,0 +1,105 @@
+"""Tests for pure helpers in ``src/clip_editor.py``."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.clip_editor import (
+    EXPORT_PRESETS,
+    ExportPreset,
+    _double_bitrate,
+    _high_quality_encode_options,
+    _safe_name,
+    _source_fps,
+)
+
+
+class TestSafeName:
+    def test_has_prefix_and_suffix(self):
+        name = _safe_name("trim")
+        assert name.startswith("trim_")
+        assert name.endswith(".mp4")
+
+    def test_unique(self):
+        names = {_safe_name("x") for _ in range(50)}
+        assert len(names) == 50
+
+    def test_includes_random_hex(self):
+        name = _safe_name("foo")
+        # foo_<12 hex>.mp4 = "foo_" + 12 chars + ".mp4"
+        stem = name.rsplit(".", 1)[0]
+        hex_part = stem.rsplit("_", 1)[1]
+        assert len(hex_part) == 12
+        assert all(c in "0123456789abcdef" for c in hex_part)
+
+
+class TestDoubleBitrate:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("10M", "20M"),
+            ("5M", "10M"),
+            ("192k", "384k"),
+            ("128k", "256k"),
+            ("2.5M", "5M"),
+            ("12M", "24M"),
+        ],
+    )
+    def test_doubles(self, value, expected):
+        assert _double_bitrate(value) == expected
+
+    def test_case_insensitive(self):
+        assert _double_bitrate("10m") == "20M"
+        assert _double_bitrate("192K") == "384k"
+
+    def test_unknown_unit_passthrough(self):
+        assert _double_bitrate("1000") == "1000"
+        assert _double_bitrate("10G") == "10G"
+
+
+class TestSourceFps:
+    def test_uses_clip_fps(self):
+        clip = SimpleNamespace(fps=29.97)
+        assert _source_fps(clip) == pytest.approx(29.97)
+
+    def test_falls_back_to_30_for_zero(self):
+        assert _source_fps(SimpleNamespace(fps=0)) == 30.0
+
+    def test_falls_back_for_none(self):
+        assert _source_fps(SimpleNamespace(fps=None)) == 30.0
+
+    def test_falls_back_for_negative(self):
+        assert _source_fps(SimpleNamespace(fps=-1)) == 30.0
+
+
+class TestHighQualityEncodeOptions:
+    def test_shape_contains_required_keys(self):
+        opts = _high_quality_encode_options(30)
+        assert opts["codec"] == "libx264"
+        assert opts["audio_codec"] == "aac"
+        assert opts["fps"] == 30
+        assert opts["preset"] == "slow"
+        assert "ffmpeg_params" in opts
+
+    def test_propagates_fps(self):
+        assert _high_quality_encode_options(60)["fps"] == 60
+
+    def test_ffmpeg_params_contain_crf_and_faststart(self):
+        params = _high_quality_encode_options(30)["ffmpeg_params"]
+        assert "-crf" in params
+        assert "+faststart" in params
+        assert "yuv420p" in params
+
+
+class TestExportPresets:
+    @pytest.mark.parametrize("name", ["tiktok", "reels", "shorts"])
+    def test_known_presets_are_vertical_1080p(self, name):
+        preset = EXPORT_PRESETS[name]
+        assert isinstance(preset, ExportPreset)
+        assert preset.width == 1080
+        assert preset.height == 1920
+
+    def test_bitrate_format(self):
+        for preset in EXPORT_PRESETS.values():
+            assert preset.video_bitrate.endswith("M")
+            assert preset.audio_bitrate.endswith("k")

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -1,0 +1,152 @@
+"""Tests for ``src/config.py`` helpers and Config construction."""
+
+import pytest
+
+from src.config import Config, get_config, set_config_override
+
+
+class TestGetOptionalEnv:
+    def test_absent_returns_none(self, monkeypatch):
+        monkeypatch.delenv("X_TEST_VAR", raising=False)
+        assert Config._get_optional_env("X_TEST_VAR") is None
+
+    def test_blank_returns_none(self, monkeypatch):
+        monkeypatch.setenv("X_TEST_VAR", "   ")
+        assert Config._get_optional_env("X_TEST_VAR") is None
+
+    def test_returns_stripped_value(self, monkeypatch):
+        monkeypatch.setenv("X_TEST_VAR", "  hello  ")
+        assert Config._get_optional_env("X_TEST_VAR") == "hello"
+
+
+class TestGetBoolEnv:
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "TRUE", "Yes"])
+    def test_truthy(self, monkeypatch, value):
+        monkeypatch.setenv("X_BOOL", value)
+        assert Config._get_bool_env("X_BOOL", default=False) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "FALSE"])
+    def test_falsy(self, monkeypatch, value):
+        monkeypatch.setenv("X_BOOL", value)
+        assert Config._get_bool_env("X_BOOL", default=True) is False
+
+    def test_unknown_uses_default(self, monkeypatch):
+        monkeypatch.setenv("X_BOOL", "maybe")
+        assert Config._get_bool_env("X_BOOL", default=True) is True
+        assert Config._get_bool_env("X_BOOL", default=False) is False
+
+    def test_absent_uses_default(self, monkeypatch):
+        monkeypatch.delenv("X_BOOL", raising=False)
+        assert Config._get_bool_env("X_BOOL", default=True) is True
+
+
+class TestGetCsvEnv:
+    def test_absent_returns_default(self, monkeypatch):
+        monkeypatch.delenv("X_CSV", raising=False)
+        assert Config._get_csv_env("X_CSV", ["a", "b"]) == ["a", "b"]
+
+    def test_empty_returns_default(self, monkeypatch):
+        monkeypatch.setenv("X_CSV", "")
+        assert Config._get_csv_env("X_CSV", ["a"]) == ["a"]
+
+    def test_trims_and_splits(self, monkeypatch):
+        monkeypatch.setenv("X_CSV", " one , two,  three  ")
+        assert Config._get_csv_env("X_CSV", []) == ["one", "two", "three"]
+
+    def test_skips_blanks(self, monkeypatch):
+        monkeypatch.setenv("X_CSV", "a,,b,  ,c")
+        assert Config._get_csv_env("X_CSV", []) == ["a", "b", "c"]
+
+
+class TestNormalizeApifyQuality:
+    @pytest.mark.parametrize("value", ["360", "480", "720", "1080"])
+    def test_valid(self, value):
+        assert Config._normalize_apify_quality(value) == value
+
+    @pytest.mark.parametrize("value", [None, "", "4k", "2160", "junk"])
+    def test_falls_back_to_1080(self, value):
+        assert Config._normalize_apify_quality(value) == "1080"
+
+    def test_trims_whitespace(self):
+        assert Config._normalize_apify_quality("  720  ") == "720"
+
+
+class TestNormalizeYoutubeMetadataProvider:
+    def test_data_api_alias(self):
+        assert (
+            Config._normalize_youtube_metadata_provider("youtube_data_api")
+            == "youtube_data_api"
+        )
+        assert (
+            Config._normalize_youtube_metadata_provider("YOUTUBE_DATA_API")
+            == "youtube_data_api"
+        )
+
+    @pytest.mark.parametrize("value", [None, "", "yt_dlp", "anything-else"])
+    def test_defaults_to_ytdlp(self, value):
+        assert Config._normalize_youtube_metadata_provider(value) == "yt_dlp"
+
+
+class TestInferDefaultLlm:
+    def test_google_preferred(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("LLM", raising=False)
+        cfg = Config()
+        assert cfg.llm.startswith("google-gla:")
+
+    def test_openai_fallback(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("LLM", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "key")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        cfg = Config()
+        assert cfg.llm.startswith("openai:")
+
+    def test_anthropic_fallback(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("LLM", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        cfg = Config()
+        assert cfg.llm.startswith("anthropic:")
+
+
+class TestResolveYoutubeDataApiKey:
+    def test_prefers_dedicated_key(self, monkeypatch):
+        monkeypatch.setenv("YOUTUBE_DATA_API_KEY", "yt-key")
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+        cfg = Config()
+        assert cfg.resolve_youtube_data_api_key() == "yt-key"
+
+    def test_falls_back_to_google_key(self, monkeypatch):
+        monkeypatch.delenv("YOUTUBE_DATA_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+        cfg = Config()
+        assert cfg.resolve_youtube_data_api_key() == "google-key"
+
+    def test_returns_none_when_no_keys(self, monkeypatch):
+        monkeypatch.delenv("YOUTUBE_DATA_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        cfg = Config()
+        assert cfg.resolve_youtube_data_api_key() is None
+
+
+class TestGetConfigOverride:
+    def test_override_is_returned(self):
+        sentinel = Config()
+        set_config_override(sentinel)
+        try:
+            assert get_config() is sentinel
+        finally:
+            set_config_override(None)
+
+    def test_without_override_returns_fresh(self):
+        set_config_override(None)
+        cfg_a = get_config()
+        cfg_b = get_config()
+        assert isinstance(cfg_a, Config)
+        assert isinstance(cfg_b, Config)
+        # fresh instances each time
+        assert cfg_a is not cfg_b

--- a/backend/tests/unit/test_email_services.py
+++ b/backend/tests/unit/test_email_services.py
@@ -1,0 +1,209 @@
+"""Tests for email service layer (``email_service``, ``task_completion_email_service``,
+``subscription_email_service``). The Resend HTTP call is mocked."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.services import email_service as es
+from src.services.email_service import (
+    EmailContent,
+    ResendEmailService,
+    first_name_for,
+)
+from src.services.subscription_email_service import SubscriptionEmailService
+from src.services.task_completion_email_service import (
+    TaskCompletionEmailService,
+    TaskCompletionRecipient,
+)
+
+
+class TestFirstNameFor:
+    def test_uses_explicit_first_name(self):
+        assert first_name_for(first_name="Jin", full_name="Jin Kim") == "Jin"
+
+    def test_trims_whitespace(self):
+        assert first_name_for(first_name="  Jin  ") == "Jin"
+
+    def test_falls_back_to_first_token_of_full_name(self):
+        assert first_name_for(first_name=None, full_name="Jin Kim") == "Jin"
+
+    def test_default_when_both_missing(self):
+        assert first_name_for() == "there"
+        assert first_name_for(first_name="", full_name="") == "there"
+
+    def test_custom_default(self):
+        assert first_name_for(first_name=None, full_name=None, default="friend") == "friend"
+
+    def test_whitespace_only_falls_through(self):
+        assert first_name_for(first_name="   ", full_name="   ") == "there"
+
+
+def _fake_config(api_key="key", from_email="SupoClip <no@reply>"):
+    return SimpleNamespace(
+        resend_api_key=api_key,
+        resend_from_email=from_email,
+        app_base_url="https://supoclip.test",
+    )
+
+
+class TestResendEmailService:
+    def test_is_configured_when_both_set(self):
+        svc = ResendEmailService(_fake_config())
+        assert svc.is_configured is True
+
+    def test_not_configured_without_api_key(self):
+        svc = ResendEmailService(_fake_config(api_key=""))
+        assert svc.is_configured is False
+
+    def test_not_configured_without_from_email(self):
+        svc = ResendEmailService(_fake_config(from_email=""))
+        assert svc.is_configured is False
+
+    @pytest.mark.asyncio
+    async def test_send_email_raises_when_not_configured(self):
+        svc = ResendEmailService(_fake_config(api_key=""))
+        with pytest.raises(RuntimeError, match="Resend is not configured"):
+            await svc.send_email(
+                "user@example.com",
+                EmailContent(subject="x", html="<p>h</p>", text="t"),
+            )
+
+    @pytest.mark.asyncio
+    async def test_send_email_calls_resend_with_params(self, monkeypatch):
+        svc = ResendEmailService(_fake_config())
+        captured = {}
+
+        def fake_send(params):
+            captured["params"] = dict(params)
+            return {"id": "email-id-1"}
+
+        monkeypatch.setattr(es.resend.Emails, "send", fake_send, raising=False)
+        result = await svc.send_email(
+            "user@example.com",
+            EmailContent(subject="Hi", html="<p>hi</p>", text="hi"),
+        )
+        assert result == {"id": "email-id-1"}
+        params = captured["params"]
+        assert params["to"] == ["user@example.com"]
+        assert params["subject"] == "Hi"
+        assert params["from"] == "SupoClip <no@reply>"
+
+
+class TestTaskCompletionEmailService:
+    def test_is_configured_delegates(self):
+        svc = TaskCompletionEmailService(_fake_config(api_key=""))
+        assert svc.is_configured is False
+        svc2 = TaskCompletionEmailService(_fake_config())
+        assert svc2.is_configured is True
+
+    def test_build_email_content_escapes_and_includes_url(self):
+        svc = TaskCompletionEmailService(_fake_config())
+        recipient = TaskCompletionRecipient(email="u@x.com", first_name="Jin", name="Jin Kim")
+        content = svc._build_task_completed_email(
+            recipient=recipient,
+            task_id="task-42",
+            source_title="<My> Video",
+            clips_count=3,
+        )
+        assert "Hi Jin" in content.html
+        assert "Hi Jin" in content.text
+        # source_title is HTML-escaped in html view
+        assert "&lt;My&gt; Video" in content.html
+        # Plaintext keeps the original
+        assert "<My> Video" in content.text
+        assert "https://supoclip.test/tasks/task-42" in content.html
+        assert "3 clips" in content.text
+
+    def test_build_singular_clip_label(self):
+        svc = TaskCompletionEmailService(_fake_config())
+        recipient = TaskCompletionRecipient(email="u@x.com", first_name=None, name=None)
+        content = svc._build_task_completed_email(
+            recipient=recipient,
+            task_id="t",
+            source_title=None,
+            clips_count=1,
+        )
+        assert "1 clip" in content.text
+        assert "1 clips" not in content.text
+        # Default greeting "there" when no names provided
+        assert "Hi there" in content.text
+        # Fallback for missing title
+        assert "your video" in content.text
+
+    @pytest.mark.asyncio
+    async def test_send_task_completed_email_calls_resend(self, monkeypatch):
+        svc = TaskCompletionEmailService(_fake_config())
+        captured = {}
+
+        def fake_send(params):
+            captured["params"] = dict(params)
+            return {"id": "ok"}
+
+        monkeypatch.setattr(es.resend.Emails, "send", fake_send, raising=False)
+        result = await svc.send_task_completed_email(
+            recipient=TaskCompletionRecipient(email="a@b.com", first_name="Jin"),
+            task_id="t1",
+            source_title="My Source",
+            clips_count=2,
+        )
+        assert result == {"id": "ok"}
+        assert captured["params"]["to"] == ["a@b.com"]
+        assert "ready" in captured["params"]["subject"].lower()
+
+
+class TestSubscriptionEmailService:
+    def _user(self, **overrides):
+        defaults = dict(
+            email="u@x.com",
+            name="Jin Kim",
+            first_name=None,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_subscribed_content(self):
+        svc = SubscriptionEmailService(_fake_config())
+        content = svc._build_subscribed_email(self._user())
+        assert "Hi Jin" in content.text
+        assert "subscribing" in content.subject.lower() or "thanks" in content.subject.lower()
+
+    def test_unsubscribed_content(self):
+        svc = SubscriptionEmailService(_fake_config())
+        content = svc._build_unsubscribed_email(self._user())
+        assert "Hi Jin" in content.text
+        assert "sorry" in content.subject.lower() or "cancel" in content.html.lower()
+
+    def test_first_name_fallback_default(self):
+        svc = SubscriptionEmailService(_fake_config())
+        user = self._user(name=None, first_name=None)
+        content = svc._build_subscribed_email(user)
+        assert "Hi there" in content.text
+
+    @pytest.mark.asyncio
+    async def test_send_subscribed_email_calls_resend(self, monkeypatch):
+        svc = SubscriptionEmailService(_fake_config())
+        sent = {}
+
+        def fake_send(params):
+            sent["p"] = dict(params)
+            return {"id": "s1"}
+
+        monkeypatch.setattr(es.resend.Emails, "send", fake_send, raising=False)
+        await svc.send_subscribed_email(self._user())
+        assert sent["p"]["to"] == ["u@x.com"]
+
+    @pytest.mark.asyncio
+    async def test_send_unsubscribed_email_calls_resend(self, monkeypatch):
+        svc = SubscriptionEmailService(_fake_config())
+        sent = {}
+
+        def fake_send(params):
+            sent["p"] = dict(params)
+            return {"id": "u1"}
+
+        monkeypatch.setattr(es.resend.Emails, "send", fake_send, raising=False)
+        await svc.send_unsubscribed_email(self._user())
+        assert sent["p"]["to"] == ["u@x.com"]

--- a/backend/tests/unit/test_fit_renderer.py
+++ b/backend/tests/unit/test_fit_renderer.py
@@ -1,0 +1,45 @@
+"""Tests for ``src/fit_renderer.py`` pure helpers + light integration."""
+
+import numpy as np
+import pytest
+
+from src.fit_renderer import _blur_frame, _round_to_even
+
+
+class TestRoundToEven:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            (0, 0),
+            (1, 0),
+            (2, 2),
+            (3, 2),
+            (1080, 1080),
+            (1081, 1080),
+            (1920, 1920),
+            (1921, 1920),
+        ],
+    )
+    def test_rounds_down_to_even(self, value, expected):
+        assert _round_to_even(value) == expected
+
+
+class TestBlurFrame:
+    def test_returns_same_shape(self):
+        frame = np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8)
+        blurred = _blur_frame(frame, kernel=5)
+        assert blurred.shape == frame.shape
+        assert blurred.dtype == frame.dtype
+
+    def test_forces_odd_kernel(self):
+        frame = np.zeros((50, 50, 3), dtype=np.uint8)
+        # Even kernel → internally bumped to odd; should not raise.
+        _blur_frame(frame, kernel=4)
+
+    def test_blur_is_not_identity(self):
+        frame = np.zeros((30, 30, 3), dtype=np.uint8)
+        frame[15, 15] = 255  # single bright pixel at center
+        blurred = _blur_frame(frame, kernel=5)
+        # With a proper Gaussian blur, the bright pixel spreads to neighbors
+        assert blurred[14, 15, 0] > 0
+        assert blurred[15, 15, 0] < 255

--- a/backend/tests/unit/test_font_registry_helpers.py
+++ b/backend/tests/unit/test_font_registry_helpers.py
@@ -1,0 +1,92 @@
+"""Tests for pure helpers in ``src/font_registry.py``."""
+
+import pytest
+
+from src.font_registry import (
+    _display_name,
+    _lookup_meta,
+    build_user_font_stem,
+    sanitize_font_stem,
+    sanitize_user_id_for_path,
+)
+
+
+class TestDisplayName:
+    @pytest.mark.parametrize(
+        "stem,expected",
+        [
+            ("tiktok-sans-regular", "Tiktok Sans Regular"),
+            ("THEBOLDFONT", "Theboldfont"),
+            ("noto_sans_kr", "Noto Sans Kr"),
+            ("  padded  ", "Padded"),
+        ],
+    )
+    def test_humanizes(self, stem, expected):
+        assert _display_name(stem) == expected
+
+
+class TestSanitizeUserIdForPath:
+    @pytest.mark.parametrize(
+        "user_id,expected",
+        [
+            ("abc123", "abc123"),
+            ("user-with-dashes", "user-with-dashes"),
+            ("user_with_underscore", "user_with_underscore"),
+            ("user@example.com", "user-example-com"),
+            ("/path/traversal/../etc", "path-traversal----etc"),
+            ("", "user"),
+            ("---", "user"),
+        ],
+    )
+    def test_sanitizes(self, user_id, expected):
+        assert sanitize_user_id_for_path(user_id) == expected
+
+
+class TestSanitizeFontStem:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("Inter-Regular.ttf", "Inter-Regular"),
+            ("My Font.otf", "My-Font"),
+            ("evil$name!.ttf", "evil-name"),
+            ("Only_Allowed_Chars-123", "Only_Allowed_Chars-123"),
+        ],
+    )
+    def test_sanitizes(self, value, expected):
+        assert sanitize_font_stem(value) == expected
+
+    @pytest.mark.parametrize("value", ["---.ttf", "!@#.ttf", "   .ttf"])
+    def test_invalid_raises(self, value):
+        with pytest.raises(ValueError):
+            sanitize_font_stem(value)
+
+
+class TestBuildUserFontStem:
+    def test_prefixes_and_lowercases(self):
+        stem = build_user_font_stem("user-123", "MyFont-Regular")
+        assert stem == "usr-user-123-myfont-regular"
+
+    def test_sanitizes_user_id(self):
+        stem = build_user_font_stem("user@example.com", "Inter")
+        assert stem == "usr-user-example-com-inter"
+
+    def test_rejects_bad_stem(self):
+        with pytest.raises(ValueError):
+            build_user_font_stem("user", "---")
+
+
+class TestLookupMeta:
+    def test_korean_hint_detection(self):
+        meta = _lookup_meta("MyFont-KR")
+        assert meta["language"] == "korean"
+
+    def test_hansans_is_korean(self):
+        assert _lookup_meta("BlackHanSans-Regular")["language"] == "korean"
+
+    def test_latin_default(self):
+        assert _lookup_meta("Inter-Regular")["language"] == "latin"
+
+    def test_display_name_present(self):
+        meta = _lookup_meta("some-random-font")
+        assert "display_name" in meta
+        assert meta["display_name"] == "Some Random Font"

--- a/backend/tests/unit/test_font_registry_lookup.py
+++ b/backend/tests/unit/test_font_registry_lookup.py
@@ -1,0 +1,206 @@
+"""Filesystem-driven tests for ``src/font_registry.py``.
+
+Uses ``tmp_path`` and monkeypatches ``FONTS_DIR`` so tests exercise the real
+lookup/collection code without touching the repo's actual fonts directory.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from src import font_registry as fr
+
+
+def _write_font(path: Path) -> None:
+    """Write a minimal placeholder — contents don't matter for registry logic."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"\x00" * 8)
+
+
+@pytest.fixture
+def fake_fonts_dir(tmp_path: Path, monkeypatch):
+    """Redirect FONTS_DIR and USER_FONTS_DIR to a clean tmp directory."""
+    fonts_dir = tmp_path / "fonts"
+    user_dir = fonts_dir / "users"
+    fonts_dir.mkdir()
+    user_dir.mkdir()
+    monkeypatch.setattr(fr, "FONTS_DIR", fonts_dir)
+    monkeypatch.setattr(fr, "USER_FONTS_DIR", user_dir)
+    return fonts_dir
+
+
+class TestHasVariant:
+    def test_finds_bold_sibling_via_lowercase_token(self, fake_fonts_dir):
+        # ``_has_variant`` builds candidates with the lowercase token suffix,
+        # e.g. ``stem + "-bold"``. On case-sensitive filesystems (Linux/Docker)
+        # the on-disk file must match that casing exactly.
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        _write_font(fake_fonts_dir / "Inter-bold.ttf")
+        base = fake_fonts_dir / "Inter.ttf"
+        variant = fr._has_variant(base, fr._BOLD_TOKENS)
+        assert variant == fake_fonts_dir / "Inter-bold.ttf"
+
+    def test_finds_italic_sibling_via_lowercase_token(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Roboto.ttf")
+        _write_font(fake_fonts_dir / "Roboto-italic.ttf")
+        base = fake_fonts_dir / "Roboto.ttf"
+        variant = fr._has_variant(base, fr._ITALIC_TOKENS)
+        assert variant == fake_fonts_dir / "Roboto-italic.ttf"
+
+    def test_replaces_regular_with_bold(self, fake_fonts_dir):
+        # Regular → Bold replacement path IS case-insensitive via re.IGNORECASE.
+        _write_font(fake_fonts_dir / "MyFont-Regular.ttf")
+        _write_font(fake_fonts_dir / "MyFont-Bold.ttf")
+        base = fake_fonts_dir / "MyFont-Regular.ttf"
+        variant = fr._has_variant(base, fr._BOLD_TOKENS)
+        assert variant == fake_fonts_dir / "MyFont-Bold.ttf"
+
+    def test_no_variant_returns_none(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Solo.ttf")
+        base = fake_fonts_dir / "Solo.ttf"
+        assert fr._has_variant(base, fr._BOLD_TOKENS) is None
+
+
+class TestDetectVariants:
+    def test_returns_bold_and_italic_paths(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        _write_font(fake_fonts_dir / "Inter-bold.ttf")
+        _write_font(fake_fonts_dir / "Inter-italic.ttf")
+        result = fr.detect_variants(fake_fonts_dir / "Inter.ttf")
+        assert result["bold_path"] is not None
+        assert "bold" in result["bold_path"].lower()
+        assert result["italic_path"] is not None
+        assert "italic" in result["italic_path"].lower()
+
+    def test_only_bold_exists(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Solo.ttf")
+        _write_font(fake_fonts_dir / "Solo-bold.ttf")
+        result = fr.detect_variants(fake_fonts_dir / "Solo.ttf")
+        assert result["bold_path"] is not None
+        assert result["italic_path"] is None
+
+
+class TestCollectFontsFromDir:
+    def test_empty_dir_returns_empty(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        assert fr._collect_fonts_from_dir(empty, scope="system") == []
+
+    def test_nonexistent_dir_returns_empty(self, tmp_path):
+        nowhere = tmp_path / "does-not-exist"
+        assert fr._collect_fonts_from_dir(nowhere, scope="system") == []
+
+    def test_primary_font_is_listed(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        fonts = fr._collect_fonts_from_dir(fake_fonts_dir, scope="system")
+        assert len(fonts) == 1
+        assert fonts[0]["name"] == "Inter"
+        assert fonts[0]["scope"] == "system"
+        assert fonts[0]["format"] == "ttf"
+
+    def test_bold_variant_hidden_when_sibling_present(self, fake_fonts_dir):
+        # Use stem-with-Regular so the Regular→Bold replacement path (which
+        # is case-insensitive) handles the variant detection.
+        _write_font(fake_fonts_dir / "MyFont-Regular.ttf")
+        _write_font(fake_fonts_dir / "MyFont-Bold.ttf")
+        fonts = fr._collect_fonts_from_dir(fake_fonts_dir, scope="system")
+        names = {f["name"] for f in fonts}
+        # The primary stem is "MyFont-Regular", the Bold variant is hidden
+        # because a "MyFont-Regular" sibling exists for it.
+        assert "MyFont-Regular" in names
+        assert "MyFont-Bold" not in names
+        primary = next(f for f in fonts if f["name"] == "MyFont-Regular")
+        assert primary["has_bold_variant"] is True
+
+    def test_variable_font_flagged(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Pretendard-Variable.ttf")
+        fonts = fr._collect_fonts_from_dir(fake_fonts_dir, scope="system")
+        assert fonts[0]["is_variable"] is True
+        assert fonts[0]["language"] == "korean"
+
+    def test_korean_metadata(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "BlackHanSans-Regular.ttf")
+        fonts = fr._collect_fonts_from_dir(fake_fonts_dir, scope="system")
+        assert fonts[0]["language"] == "korean"
+
+
+class TestGetAvailableFonts:
+    def test_sorts_korean_first(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        _write_font(fake_fonts_dir / "Pretendard-Variable.ttf")
+        fonts = fr.get_available_fonts()
+        # Korean first, then Latin
+        assert fonts[0]["language"] == "korean"
+        assert fonts[-1]["language"] == "latin"
+
+    def test_includes_user_fonts(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        user_id = "user-1"
+        user_dir = fr.get_user_fonts_dir(user_id)
+        _write_font(user_dir / "MyCustomFont.ttf")
+        fonts = fr.get_available_fonts(user_id=user_id)
+        names = [f["name"] for f in fonts]
+        assert "MyCustomFont" in names
+        # User font is marked as scope=user
+        custom = next(f for f in fonts if f["name"] == "MyCustomFont")
+        assert custom["scope"] == "user"
+
+
+class TestFindFontPathLookup:
+    def test_exact_filename_match(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        path = fr.find_font_path("Inter.ttf")
+        assert path is not None
+        assert path.name == "Inter.ttf"
+
+    def test_stem_only_finds_ttf(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        path = fr.find_font_path("Inter")
+        assert path is not None
+
+    def test_normalized_match(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        # Normalized lookup strips non-alphanumeric and lowercases
+        path = fr.find_font_path("inter")
+        assert path is not None
+
+    def test_user_scoped_font(self, fake_fonts_dir):
+        user_id = "ux1"
+        user_dir = fr.get_user_fonts_dir(user_id)
+        _write_font(user_dir / "Custom.ttf")
+        path = fr.find_font_path("Custom", user_id=user_id)
+        assert path is not None
+
+    def test_missing_returns_none(self, fake_fonts_dir):
+        assert fr.find_font_path("NonExistent") is None
+
+
+class TestIsFontAccessible:
+    def test_true_when_font_exists(self, fake_fonts_dir):
+        _write_font(fake_fonts_dir / "Inter.ttf")
+        assert fr.is_font_accessible("Inter", user_id="x") is True
+
+    def test_false_when_missing(self, fake_fonts_dir):
+        assert fr.is_font_accessible("MissingFont", user_id="x") is False
+
+
+class TestFontCoversText:
+    def test_empty_text_always_covered(self):
+        # Any path works — empty text short-circuits before IO
+        assert fr.font_covers_text(Path("/bogus/path"), "") is True
+
+    def test_unknown_coverage_defaults_to_true(self, monkeypatch):
+        # When codepoints come back empty (fontTools unavailable or failed),
+        # the helper defaults to True so the render still proceeds.
+        monkeypatch.setattr(fr, "_font_codepoints", lambda _p: frozenset())
+        assert fr.font_covers_text(Path("/bogus"), "hello") is True
+
+    def test_text_missing_codepoint(self, monkeypatch):
+        # ASCII 'a' only → text with '한' should not be covered.
+        monkeypatch.setattr(fr, "_font_codepoints", lambda _p: frozenset({ord("a")}))
+        assert fr.font_covers_text(Path("/bogus"), "aaa") is True
+        assert fr.font_covers_text(Path("/bogus"), "a한") is False
+
+    def test_whitespace_ignored(self, monkeypatch):
+        monkeypatch.setattr(fr, "_font_codepoints", lambda _p: frozenset({ord("a")}))
+        assert fr.font_covers_text(Path("/bogus"), "a a a") is True

--- a/backend/tests/unit/test_font_registry_security.py
+++ b/backend/tests/unit/test_font_registry_security.py
@@ -1,0 +1,62 @@
+"""Path-traversal defense tests for ``font_registry.find_font_path``."""
+
+from pathlib import Path
+
+import pytest
+
+from src.font_registry import _is_path_inside, find_font_path
+
+
+class TestIsPathInside:
+    def test_direct_child_is_inside(self, tmp_path):
+        f = tmp_path / "a.ttf"
+        f.write_bytes(b"")
+        assert _is_path_inside(f, tmp_path) is True
+
+    def test_nested_child_is_inside(self, tmp_path):
+        nested = tmp_path / "sub" / "deeper" / "a.ttf"
+        nested.parent.mkdir(parents=True)
+        nested.write_bytes(b"")
+        assert _is_path_inside(nested, tmp_path) is True
+
+    def test_sibling_is_not_inside(self, tmp_path):
+        sibling = tmp_path.parent / "other.ttf"
+        assert _is_path_inside(sibling, tmp_path) is False
+
+    def test_traversal_resolves_outside(self, tmp_path):
+        traversal = tmp_path / ".." / "escape.ttf"
+        assert _is_path_inside(traversal, tmp_path) is False
+
+    def test_absolute_outside_path(self, tmp_path):
+        elsewhere = Path("/") / "etc" / "passwd"
+        assert _is_path_inside(elsewhere, tmp_path) is False
+
+
+class TestFindFontPathTraversalRejection:
+    @pytest.mark.parametrize(
+        "malicious",
+        [
+            "../secret",
+            "../../etc/passwd",
+            "..\\..\\windows\\system32\\cmd",
+            "some/../escape",
+            "/absolute/path",
+            "C:\\Windows\\notepad.exe",
+            "\x00nullbyte",
+            "legit.ttf/../evil",
+        ],
+    )
+    def test_rejects_traversal_tokens(self, malicious):
+        assert find_font_path(malicious) is None
+
+    def test_empty_returns_none(self):
+        assert find_font_path("") is None
+        assert find_font_path("   ") is None
+
+    def test_plain_name_not_rejected(self):
+        # A well-formed name without traversal tokens is allowed through to
+        # the filesystem lookup (may still miss — we only care that the
+        # guard didn't short-circuit it).
+        # Returns None because the font does not exist, but no exception.
+        result = find_font_path("DoesNotExistFont-Regular")
+        assert result is None or isinstance(result, Path)

--- a/backend/tests/unit/test_models.py
+++ b/backend/tests/unit/test_models.py
@@ -1,0 +1,41 @@
+"""Tests for SQLAlchemy models helpers in ``src/models.py``."""
+
+import uuid
+
+from src.models import Source, generate_uuid_string
+
+
+class TestGenerateUuidString:
+    def test_returns_string(self):
+        value = generate_uuid_string()
+        assert isinstance(value, str)
+
+    def test_is_valid_uuid(self):
+        value = generate_uuid_string()
+        # Will raise if not a valid UUID
+        parsed = uuid.UUID(value)
+        assert str(parsed) == value
+
+    def test_unique_per_call(self):
+        ids = {generate_uuid_string() for _ in range(50)}
+        assert len(ids) == 50
+
+
+class TestSourceDecideSourceType:
+    def test_youtube_url(self):
+        # Only checks for the substring "youtube" — youtu.be is not matched.
+        source = Source.__new__(Source)
+        assert source.decide_source_type("https://www.youtube.com/watch?v=abc") == "youtube"
+        assert source.decide_source_type("youtube.com/shorts/xyz") == "youtube"
+
+    def test_non_youtube_url(self):
+        source = Source.__new__(Source)
+        assert source.decide_source_type("https://example.com/video.mp4") == "video_url"
+        # youtu.be short links are classified as video_url — this is the
+        # actual (simple substring) behavior, captured here so a future
+        # rename cannot change it silently.
+        assert source.decide_source_type("https://youtu.be/abc") == "video_url"
+
+    def test_empty_url_is_video(self):
+        source = Source.__new__(Source)
+        assert source.decide_source_type("") == "video_url"

--- a/backend/tests/unit/test_observability.py
+++ b/backend/tests/unit/test_observability.py
@@ -1,0 +1,101 @@
+"""Tests for ``src/observability.py``."""
+
+import json
+import logging
+
+import pytest
+
+from src.observability import (
+    JsonLogFormatter,
+    TraceIdFilter,
+    clear_trace_id,
+    generate_trace_id,
+    get_trace_id,
+    set_trace_id,
+)
+
+
+class TestTraceIdContext:
+    def test_default_is_dash(self):
+        clear_trace_id()
+        assert get_trace_id() == "-"
+
+    def test_set_and_get(self):
+        set_trace_id("abc123")
+        assert get_trace_id() == "abc123"
+        clear_trace_id()
+
+    def test_clear_resets(self):
+        set_trace_id("abc")
+        clear_trace_id()
+        assert get_trace_id() == "-"
+
+
+class TestGenerateTraceId:
+    def test_unique(self):
+        ids = {generate_trace_id() for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_hex_format(self):
+        value = generate_trace_id()
+        assert len(value) == 32
+        assert all(c in "0123456789abcdef" for c in value)
+
+
+class TestTraceIdFilter:
+    def test_attaches_trace_id(self):
+        set_trace_id("xyz")
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="hi",
+            args=(),
+            exc_info=None,
+        )
+        assert TraceIdFilter().filter(record) is True
+        assert record.trace_id == "xyz"
+        clear_trace_id()
+
+
+class TestJsonLogFormatter:
+    def _make_record(self, level=logging.INFO, exc_info=None):
+        return logging.LogRecord(
+            name="app",
+            level=level,
+            pathname=__file__,
+            lineno=1,
+            msg="hello %s",
+            args=("world",),
+            exc_info=exc_info,
+        )
+
+    def test_produces_valid_json(self):
+        record = self._make_record()
+        record.trace_id = "traceabc"
+        output = JsonLogFormatter().format(record)
+        payload = json.loads(output)
+        assert payload["level"] == "INFO"
+        assert payload["logger"] == "app"
+        assert payload["message"] == "hello world"
+        assert payload["trace_id"] == "traceabc"
+        assert "timestamp" in payload
+
+    def test_missing_trace_id_defaults_to_dash(self):
+        record = self._make_record()
+        output = JsonLogFormatter().format(record)
+        payload = json.loads(output)
+        assert payload["trace_id"] == "-"
+
+    def test_includes_exception(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            import sys
+
+            record = self._make_record(level=logging.ERROR, exc_info=sys.exc_info())
+        output = JsonLogFormatter().format(record)
+        payload = json.loads(output)
+        assert "exception" in payload
+        assert "ValueError" in payload["exception"]

--- a/backend/tests/unit/test_pricing.py
+++ b/backend/tests/unit/test_pricing.py
@@ -1,0 +1,74 @@
+"""Tests for the API pricing table."""
+
+import pytest
+
+from src.pricing import (
+    LLM_PRICES,
+    LLMPrice,
+    assemblyai_cost_usd,
+    get_llm_price,
+    llm_cost_usd,
+    llm_model_known,
+)
+
+
+class TestLlmCostUsd:
+    def test_known_model_computes_linear_cost(self):
+        price = LLM_PRICES["openai:gpt-4o-mini"]
+        cost = llm_cost_usd("openai:gpt-4o-mini", 1_000_000, 2_000_000)
+        expected = price.input_per_1m + 2 * price.output_per_1m
+        assert cost == pytest.approx(expected)
+
+    def test_unknown_model_returns_zero(self):
+        assert llm_cost_usd("something:never-heard-of", 10_000, 5_000) == 0.0
+
+    def test_case_insensitive_and_whitespace_tolerant(self):
+        base = llm_cost_usd("openai:gpt-4o-mini", 100, 200)
+        assert llm_cost_usd("  OpenAI:GPT-4o-MINI  ", 100, 200) == pytest.approx(base)
+
+    def test_empty_model_is_zero(self):
+        assert llm_cost_usd("", 100, 100) == 0.0
+        assert llm_cost_usd(None, 100, 100) == 0.0  # type: ignore[arg-type]
+
+
+class TestAssemblyaiCostUsd:
+    def test_best_tier_default(self):
+        assert assemblyai_cost_usd(3600, tier="best") == pytest.approx(0.37)
+
+    def test_nano_tier(self):
+        assert assemblyai_cost_usd(3600, tier="nano") == pytest.approx(0.12)
+
+    def test_unknown_tier_falls_back_to_best(self):
+        assert assemblyai_cost_usd(3600, tier="bogus") == pytest.approx(0.37)
+
+    def test_case_insensitive(self):
+        assert assemblyai_cost_usd(3600, tier="BEST") == pytest.approx(0.37)
+
+    def test_prorates_by_seconds(self):
+        assert assemblyai_cost_usd(1800, tier="best") == pytest.approx(0.185)
+
+
+class TestLlmModelKnown:
+    def test_known_true(self):
+        assert llm_model_known("openai:gpt-4o-mini") is True
+
+    def test_unknown_false(self):
+        assert llm_model_known("fictional:model") is False
+
+    def test_empty_false(self):
+        assert llm_model_known("") is False
+
+
+class TestGetLlmPrice:
+    def test_returns_price_for_known(self):
+        price = get_llm_price("anthropic:claude-opus-4-7")
+        assert isinstance(price, LLMPrice)
+        assert price.input_per_1m == 15.00
+        assert price.output_per_1m == 75.00
+
+    def test_returns_none_for_unknown(self):
+        assert get_llm_price("fake:model") is None
+
+    def test_none_input_is_none(self):
+        assert get_llm_price(None) is None
+        assert get_llm_price("") is None

--- a/backend/tests/unit/test_prompt_service.py
+++ b/backend/tests/unit/test_prompt_service.py
@@ -1,0 +1,161 @@
+"""Tests for ``src/services/prompt_service.py``.
+
+All repository calls are patched with ``AsyncMock`` — no DB required.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services import prompt_service as ps
+
+
+class TestGetPromptContent:
+    @pytest.mark.asyncio
+    async def test_unknown_key_raises(self):
+        with pytest.raises(KeyError):
+            await ps.get_prompt_content(db=object(), key="nope")
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_no_row(self, monkeypatch):
+        monkeypatch.setattr(
+            ps.PromptRepository, "get_one", AsyncMock(return_value=None)
+        )
+        result = await ps.get_prompt_content(db="db", key=ps.KEY_TRANSCRIPT_SYSTEM)
+        assert (
+            result == ps.PROMPT_DEFINITIONS[ps.KEY_TRANSCRIPT_SYSTEM].default_content
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_db_override_when_present(self, monkeypatch):
+        monkeypatch.setattr(
+            ps.PromptRepository,
+            "get_one",
+            AsyncMock(return_value={"content": "customized"}),
+        )
+        assert await ps.get_prompt_content(db="db", key=ps.KEY_TRANSCRIPT_SYSTEM) == "customized"
+
+    @pytest.mark.asyncio
+    async def test_empty_db_content_falls_back(self, monkeypatch):
+        # Empty string should NOT override the default
+        monkeypatch.setattr(
+            ps.PromptRepository,
+            "get_one",
+            AsyncMock(return_value={"content": ""}),
+        )
+        result = await ps.get_prompt_content(db="db", key=ps.KEY_TRANSCRIPT_SYSTEM)
+        assert result == ps.PROMPT_DEFINITIONS[ps.KEY_TRANSCRIPT_SYSTEM].default_content
+
+
+class TestListPrompts:
+    @pytest.mark.asyncio
+    async def test_empty_db_uses_defaults(self, monkeypatch):
+        monkeypatch.setattr(
+            ps.PromptRepository, "list_all", AsyncMock(return_value=[])
+        )
+        rows = await ps.list_prompts(db="db")
+        assert len(rows) == len(ps.PROMPT_DEFINITIONS)
+        for row in rows:
+            assert row["is_customized"] is False
+            assert row["updated_at"] is None
+            assert row["updated_by"] is None
+            defn = ps.PROMPT_DEFINITIONS[row["key"]]
+            assert row["content"] == defn.default_content
+
+    @pytest.mark.asyncio
+    async def test_merges_db_row(self, monkeypatch):
+        updated = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        monkeypatch.setattr(
+            ps.PromptRepository,
+            "list_all",
+            AsyncMock(
+                return_value=[
+                    {
+                        "key": ps.KEY_TRANSCRIPT_SYSTEM,
+                        "content": "my custom prompt",
+                        "updated_at": updated,
+                        "updated_by": "admin-1",
+                    }
+                ]
+            ),
+        )
+        rows = await ps.list_prompts(db="db")
+        customized = next(r for r in rows if r["key"] == ps.KEY_TRANSCRIPT_SYSTEM)
+        assert customized["is_customized"] is True
+        assert customized["content"] == "my custom prompt"
+        assert customized["updated_at"] == updated.isoformat()
+        assert customized["updated_by"] == "admin-1"
+
+
+class TestUpdatePrompt:
+    @pytest.mark.asyncio
+    async def test_unknown_key_raises(self, monkeypatch):
+        monkeypatch.setattr(ps.PromptRepository, "upsert", AsyncMock())
+        with pytest.raises(KeyError):
+            await ps.update_prompt(db="db", key="nope", content="x", updated_by=None)
+
+    @pytest.mark.asyncio
+    async def test_empty_content_rejected(self):
+        with pytest.raises(ValueError):
+            await ps.update_prompt(
+                db="db", key=ps.KEY_TRANSCRIPT_SYSTEM, content="", updated_by=None
+            )
+        with pytest.raises(ValueError):
+            await ps.update_prompt(
+                db="db", key=ps.KEY_TRANSCRIPT_SYSTEM, content="   \n   ", updated_by=None
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_placeholder(self):
+        # transcript_user_template requires {transcript} and {broll_instruction}
+        with pytest.raises(ValueError) as exc:
+            await ps.update_prompt(
+                db="db",
+                key=ps.KEY_TRANSCRIPT_USER_TEMPLATE,
+                content="no placeholders here",
+                updated_by=None,
+            )
+        assert "placeholder" in str(exc.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_accepts_when_all_placeholders_present(self, monkeypatch):
+        fake = AsyncMock()
+        monkeypatch.setattr(ps.PromptRepository, "upsert", fake)
+        await ps.update_prompt(
+            db="db",
+            key=ps.KEY_TRANSCRIPT_USER_TEMPLATE,
+            content="Analyze {transcript} using {broll_instruction}",
+            updated_by="me",
+        )
+        fake.assert_awaited_once()
+        assert fake.await_args.kwargs["updated_by"] == "me"
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_has_no_required_placeholders(self, monkeypatch):
+        fake = AsyncMock()
+        monkeypatch.setattr(ps.PromptRepository, "upsert", fake)
+        # transcript_system has empty placeholders tuple → any non-empty content OK
+        await ps.update_prompt(
+            db="db",
+            key=ps.KEY_TRANSCRIPT_SYSTEM,
+            content="  plain new system prompt  ",
+            updated_by="me",
+        )
+        fake.assert_awaited_once()
+        # Whitespace trimmed before persisting
+        assert fake.await_args.kwargs["content"] == "plain new system prompt"
+
+
+class TestResetPrompt:
+    @pytest.mark.asyncio
+    async def test_unknown_key_raises(self):
+        with pytest.raises(KeyError):
+            await ps.reset_prompt(db="db", key="nope")
+
+    @pytest.mark.asyncio
+    async def test_delegates_to_repo_delete(self, monkeypatch):
+        fake = AsyncMock()
+        monkeypatch.setattr(ps.PromptRepository, "delete", fake)
+        await ps.reset_prompt(db="db", key=ps.KEY_TRANSCRIPT_SYSTEM)
+        fake.assert_awaited_once_with("db", ps.KEY_TRANSCRIPT_SYSTEM)

--- a/backend/tests/unit/test_secret_service.py
+++ b/backend/tests/unit/test_secret_service.py
@@ -1,0 +1,188 @@
+"""Tests for the file-backed secret store in ``src/services/secret_service.py``.
+
+Uses ``tmp_path`` to redirect the SECRETS_DIR/SECRETS_FILE so the real
+``backend/secrets/app_secrets.json`` is never touched.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.services import secret_service as ss
+
+
+@pytest.fixture
+def fake_secrets_dir(tmp_path: Path, monkeypatch):
+    """Redirect SECRETS_DIR + SECRETS_FILE, clear environ pollution between tests."""
+    secrets_dir = tmp_path / "secrets"
+    secrets_dir.mkdir()
+    monkeypatch.setattr(ss, "SECRETS_DIR", secrets_dir)
+    monkeypatch.setattr(ss, "SECRETS_FILE", secrets_dir / "app_secrets.json")
+
+    # Snapshot + restore environ so test writes don't leak
+    saved = {k: os.environ.get(k) for k in list(ss.SECRET_DEFINITIONS.keys())}
+    yield secrets_dir
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+class TestMaskPreview:
+    def test_none_returns_none(self):
+        assert ss.mask_preview(None) is None
+        assert ss.mask_preview("") is None
+
+    def test_short_value_fully_masked(self):
+        # Under _MIN_REVEAL_LEN → no prefix/suffix reveal
+        result = ss.mask_preview("short")
+        assert result.startswith("***")
+        assert result.endswith("***")
+        assert "short" not in result
+
+    def test_long_value_shows_edges(self):
+        preview = ss.mask_preview("abcdefghijklmnop")  # 16 chars
+        assert preview.startswith("abcd")
+        assert preview.endswith("mnop")
+        assert ss.MASK_MIDDLE in preview
+
+
+class TestReadWriteFile:
+    def test_read_missing_file_returns_empty(self, fake_secrets_dir):
+        assert ss._read_file() == {}
+
+    def test_read_invalid_json_returns_empty(self, fake_secrets_dir):
+        ss.SECRETS_FILE.write_text("not{valid json", encoding="utf-8")
+        assert ss._read_file() == {}
+
+    def test_read_non_dict_returns_empty(self, fake_secrets_dir):
+        ss.SECRETS_FILE.write_text(json.dumps(["a", "b"]), encoding="utf-8")
+        assert ss._read_file() == {}
+
+    def test_write_then_read_roundtrip(self, fake_secrets_dir):
+        payload = {"ASSEMBLY_AI_API_KEY": {"value": "x", "updated_at": "t"}}
+        ss._write_file(payload)
+        assert ss._read_file() == payload
+
+    def test_write_creates_directory(self, tmp_path, monkeypatch):
+        new_dir = tmp_path / "does-not-exist-yet"
+        monkeypatch.setattr(ss, "SECRETS_DIR", new_dir)
+        monkeypatch.setattr(ss, "SECRETS_FILE", new_dir / "app_secrets.json")
+
+        ss._write_file({"key": {"value": "v"}})
+        assert new_dir.exists()
+        assert (new_dir / "app_secrets.json").exists()
+
+
+class TestListStatus:
+    def test_all_unset_when_file_empty(self, fake_secrets_dir):
+        rows = ss.list_status()
+        assert len(rows) == len(ss.SECRET_DEFINITIONS)
+        for row in rows:
+            assert row["set"] is False
+            assert row["preview"] is None
+            assert row["updated_at"] is None
+
+    def test_shows_preview_when_set(self, fake_secrets_dir):
+        ss._write_file({
+            "ASSEMBLY_AI_API_KEY": {
+                "value": "abcdefghijklmnop",
+                "updated_at": "2026-04-23T00:00:00+00:00",
+            }
+        })
+        rows = ss.list_status()
+        row = next(r for r in rows if r["name"] == "ASSEMBLY_AI_API_KEY")
+        assert row["set"] is True
+        assert row["preview"] is not None
+        assert "abcd" in row["preview"]
+        assert row["updated_at"] == "2026-04-23T00:00:00+00:00"
+
+    def test_handles_legacy_non_dict_rows(self, fake_secrets_dir):
+        # If the file somehow has a string instead of a dict, we should not crash.
+        ss._write_file({"ASSEMBLY_AI_API_KEY": "legacy-string"})  # type: ignore[dict-item]
+        rows = ss.list_status()
+        row = next(r for r in rows if r["name"] == "ASSEMBLY_AI_API_KEY")
+        assert row["set"] is False
+
+
+class TestUpsert:
+    def test_rejects_unknown_name(self, fake_secrets_dir):
+        with pytest.raises(KeyError):
+            ss.upsert("NOT_A_REGISTERED_SECRET", "value")
+
+    def test_rejects_empty_value(self, fake_secrets_dir):
+        with pytest.raises(ValueError):
+            ss.upsert("ASSEMBLY_AI_API_KEY", "")
+
+    def test_rejects_whitespace_only_value(self, fake_secrets_dir):
+        with pytest.raises(ValueError):
+            ss.upsert("ASSEMBLY_AI_API_KEY", "   \n   ")
+
+    def test_stores_and_updates_environ(self, fake_secrets_dir):
+        result = ss.upsert("ASSEMBLY_AI_API_KEY", "real-api-key-123456")
+        assert result["set"] is True
+        assert result["preview"] is not None
+        # Persisted
+        stored = ss._read_file()
+        assert stored["ASSEMBLY_AI_API_KEY"]["value"] == "real-api-key-123456"
+        # Populated environ
+        assert os.environ["ASSEMBLY_AI_API_KEY"] == "real-api-key-123456"
+        # Timestamp is ISO-8601
+        datetime.fromisoformat(stored["ASSEMBLY_AI_API_KEY"]["updated_at"])
+
+    def test_trims_whitespace(self, fake_secrets_dir):
+        ss.upsert("ASSEMBLY_AI_API_KEY", "  trimmed-value  ")
+        assert ss._read_file()["ASSEMBLY_AI_API_KEY"]["value"] == "trimmed-value"
+
+
+class TestDelete:
+    def test_unknown_name_raises(self, fake_secrets_dir):
+        with pytest.raises(KeyError):
+            ss.delete("NOT_A_REGISTERED_SECRET")
+
+    def test_missing_returns_false(self, fake_secrets_dir):
+        assert ss.delete("ASSEMBLY_AI_API_KEY") is False
+
+    def test_existing_returns_true_and_removes(self, fake_secrets_dir):
+        ss.upsert("ASSEMBLY_AI_API_KEY", "value-that-is-long-enough")
+        assert os.environ.get("ASSEMBLY_AI_API_KEY") == "value-that-is-long-enough"
+
+        assert ss.delete("ASSEMBLY_AI_API_KEY") is True
+        assert "ASSEMBLY_AI_API_KEY" not in os.environ
+        assert "ASSEMBLY_AI_API_KEY" not in ss._read_file()
+
+
+class TestHydrateEnviron:
+    def test_empty_file_returns_zero(self, fake_secrets_dir):
+        assert ss.hydrate_environ() == 0
+
+    def test_applies_stored_values(self, fake_secrets_dir):
+        os.environ.pop("ASSEMBLY_AI_API_KEY", None)
+        os.environ.pop("GOOGLE_API_KEY", None)
+        ss._write_file({
+            "ASSEMBLY_AI_API_KEY": {"value": "aaa", "updated_at": "t"},
+            "GOOGLE_API_KEY": {"value": "bbb", "updated_at": "t"},
+        })
+        count = ss.hydrate_environ()
+        assert count == 2
+        assert os.environ["ASSEMBLY_AI_API_KEY"] == "aaa"
+        assert os.environ["GOOGLE_API_KEY"] == "bbb"
+
+    def test_skips_non_dict_rows(self, fake_secrets_dir):
+        ss._write_file({
+            "ASSEMBLY_AI_API_KEY": {"value": "good", "updated_at": "t"},
+            "GARBAGE": "not-a-dict",  # type: ignore[dict-item]
+        })
+        assert ss.hydrate_environ() == 1
+
+    def test_skips_empty_values(self, fake_secrets_dir):
+        os.environ.pop("ASSEMBLY_AI_API_KEY", None)
+        ss._write_file({
+            "ASSEMBLY_AI_API_KEY": {"value": "", "updated_at": "t"},
+        })
+        assert ss.hydrate_environ() == 0
+        assert "ASSEMBLY_AI_API_KEY" not in os.environ

--- a/backend/tests/unit/test_subtitle_exporters.py
+++ b/backend/tests/unit/test_subtitle_exporters.py
@@ -1,0 +1,83 @@
+"""Tests for ``src/subtitle_exporters.py``."""
+
+import pytest
+
+from src.subtitle_exporters import (
+    DEFAULT_WORDS_PER_GROUP,
+    build_word_groups_for_clip,
+    word_groups_to_plaintext,
+    word_groups_to_srt,
+)
+
+
+def _transcript(words):
+    return {"words": words}
+
+
+def _w(text, start_ms, end_ms, speaker=None):
+    return {"text": text, "start": start_ms, "end": end_ms, "speaker": speaker}
+
+
+class TestBuildWordGroupsForClip:
+    def test_returns_empty_for_empty_transcript(self):
+        assert build_word_groups_for_clip({}, 0.0, 10.0) == []
+
+    def test_slices_and_chunks(self):
+        words = [_w(str(i), i * 1000, i * 1000 + 500) for i in range(7)]
+        groups = build_word_groups_for_clip(_transcript(words), 0.0, 10.0, words_per_group=3)
+        assert [len(g) for g in groups] == [3, 3, 1]
+
+    def test_filters_by_clip_range(self):
+        words = [
+            _w("a", 0, 500),
+            _w("b", 2000, 2500),
+            _w("c", 5000, 5500),
+        ]
+        groups = build_word_groups_for_clip(_transcript(words), 1.0, 3.0)
+        flat = [w["text"] for group in groups for w in group]
+        assert flat == ["b"]
+
+
+class TestWordGroupsToSrt:
+    def test_renders_minimal_srt(self):
+        # Absolute ms — rebase via clip_start=0
+        group = [_w("hello", 0, 400), _w("world", 500, 900)]
+        srt_text = word_groups_to_srt([group], clip_start=0.0)
+        assert "hello world" in srt_text
+        assert "00:00:00,000" in srt_text
+
+    def test_rebases_to_clip_start(self):
+        group = [_w("x", 10_000, 10_500)]
+        srt_text = word_groups_to_srt([group], clip_start=10.0)
+        # Rebased to 0 ms
+        assert "00:00:00,000" in srt_text
+
+    def test_skips_empty_groups(self):
+        assert word_groups_to_srt([[]], clip_start=0.0) == ""
+
+    def test_skips_whitespace_only_text(self):
+        group = [_w("   ", 0, 500)]
+        assert word_groups_to_srt([group], clip_start=0.0) == ""
+
+    def test_enforces_minimum_duration(self):
+        group = [_w("tight", 1000, 1000)]  # zero duration
+        srt_text = word_groups_to_srt([group], clip_start=0.0)
+        # End should be start + 100ms minimum, so it's not empty
+        assert "tight" in srt_text
+
+
+class TestWordGroupsToPlaintext:
+    def test_joins_groups_with_newlines(self):
+        groups = [
+            [_w("hello", 0, 400), _w("world", 500, 900)],
+            [_w("bye", 1000, 1400)],
+        ]
+        assert word_groups_to_plaintext(groups) == "hello world\nbye"
+
+    def test_skips_empty(self):
+        assert word_groups_to_plaintext([]) == ""
+        assert word_groups_to_plaintext([[]]) == ""
+
+
+def test_default_words_per_group_sensible():
+    assert DEFAULT_WORDS_PER_GROUP >= 1

--- a/backend/tests/unit/test_task_helpers.py
+++ b/backend/tests/unit/test_task_helpers.py
@@ -1,0 +1,90 @@
+"""Tests for pure helpers extracted from ``TaskService``."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.services._task_helpers import (
+    build_cache_key,
+    is_queued_task_stale,
+    seconds_to_mmss,
+)
+
+
+class TestBuildCacheKey:
+    def test_stable_for_identical_inputs(self):
+        a = build_cache_key("https://youtu.be/abc", "youtube", "fast")
+        b = build_cache_key("https://youtu.be/abc", "youtube", "fast")
+        assert a == b
+        assert len(a) == 64  # sha256 hex digest
+
+    def test_url_whitespace_is_trimmed(self):
+        trimmed = build_cache_key("https://youtu.be/abc", "youtube", "fast")
+        padded = build_cache_key("  https://youtu.be/abc  ", "youtube", "fast")
+        assert trimmed == padded
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            ("https://youtu.be/xyz", "youtube", "fast"),
+            ("https://youtu.be/abc", "upload", "fast"),
+            ("https://youtu.be/abc", "youtube", "thorough"),
+        ],
+    )
+    def test_different_inputs_produce_different_keys(self, fields):
+        base = build_cache_key("https://youtu.be/abc", "youtube", "fast")
+        assert build_cache_key(*fields) != base
+
+
+class TestSecondsToMmss:
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0, "00:00"),
+            (5, "00:05"),
+            (59, "00:59"),
+            (60, "01:00"),
+            (61, "01:01"),
+            (3599, "59:59"),
+            (3600, "60:00"),
+        ],
+    )
+    def test_formats(self, seconds, expected):
+        assert seconds_to_mmss(seconds) == expected
+
+    def test_fractional_rounds_to_nearest(self):
+        assert seconds_to_mmss(59.4) == "00:59"
+        assert seconds_to_mmss(59.6) == "01:00"
+
+    def test_negative_clamps_to_zero(self):
+        assert seconds_to_mmss(-5) == "00:00"
+
+
+class TestIsQueuedTaskStale:
+    def test_non_queued_tasks_never_stale(self):
+        task = {"status": "processing", "created_at": None, "updated_at": None}
+        assert is_queued_task_stale(task, timeout_seconds=60) is False
+
+    def test_missing_timestamps_are_not_stale(self):
+        task = {"status": "queued", "created_at": None, "updated_at": None}
+        assert is_queued_task_stale(task, timeout_seconds=60) is False
+
+    def test_fresh_queued_task_is_not_stale(self):
+        now = datetime.now(timezone.utc)
+        task = {"status": "queued", "created_at": now, "updated_at": now}
+        assert is_queued_task_stale(task, timeout_seconds=60) is False
+
+    def test_old_queued_task_is_stale(self):
+        old = datetime.now(timezone.utc) - timedelta(seconds=120)
+        task = {"status": "queued", "created_at": old, "updated_at": old}
+        assert is_queued_task_stale(task, timeout_seconds=60) is True
+
+    def test_falls_back_to_created_at_when_updated_missing(self):
+        old = datetime.now(timezone.utc) - timedelta(seconds=120)
+        task = {"status": "queued", "created_at": old, "updated_at": None}
+        assert is_queued_task_stale(task, timeout_seconds=60) is True
+
+    def test_naive_datetime_is_handled(self):
+        old_naive = datetime.utcnow() - timedelta(seconds=120)
+        task = {"status": "queued", "created_at": old_naive, "updated_at": old_naive}
+        assert is_queued_task_stale(task, timeout_seconds=60) is True

--- a/backend/tests/unit/test_usage_context.py
+++ b/backend/tests/unit/test_usage_context.py
@@ -1,0 +1,55 @@
+"""Tests for ``src/usage_context.py``."""
+
+from src.usage_context import (
+    UsageEvent,
+    UsageRecorder,
+    current_usage,
+    record_event,
+)
+
+
+class TestUsageEvent:
+    def test_defaults(self):
+        event = UsageEvent(service="llm")
+        assert event.service == "llm"
+        assert event.model is None
+        assert event.input_tokens == 0
+        assert event.output_tokens == 0
+        assert event.audio_seconds == 0.0
+        assert event.cost_usd == 0.0
+        assert event.metadata == {}
+
+    def test_metadata_is_per_instance(self):
+        a = UsageEvent(service="llm")
+        b = UsageEvent(service="llm")
+        a.metadata["task"] = "1"
+        assert "task" not in b.metadata
+
+
+class TestUsageRecorder:
+    def test_starts_empty(self):
+        assert UsageRecorder().events == []
+
+    def test_records_appends(self):
+        recorder = UsageRecorder()
+        recorder.record(UsageEvent(service="llm"))
+        recorder.record(UsageEvent(service="assemblyai"))
+        assert len(recorder.events) == 2
+        assert recorder.events[0].service == "llm"
+
+
+class TestRecordEvent:
+    def test_noop_when_no_recorder(self):
+        # Default context has no recorder — must not raise.
+        current_usage.set(None)
+        record_event(UsageEvent(service="llm"))  # should silently drop
+
+    def test_records_to_current(self):
+        recorder = UsageRecorder()
+        token = current_usage.set(recorder)
+        try:
+            record_event(UsageEvent(service="llm", cost_usd=0.05))
+            assert len(recorder.events) == 1
+            assert recorder.events[0].cost_usd == 0.05
+        finally:
+            current_usage.reset(token)

--- a/backend/tests/unit/test_usage_service.py
+++ b/backend/tests/unit/test_usage_service.py
@@ -1,0 +1,151 @@
+"""Tests for ``src/services/usage_service.py``.
+
+The service is a thin async wrapper over ``TaskUsageRepository`` — tests
+patch the repository class methods with ``AsyncMock`` so no DB is needed.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services import usage_service as us
+from src.usage_context import UsageEvent, UsageRecorder, current_usage
+
+
+class TestStartRecording:
+    def test_returns_fresh_recorder_and_activates_it(self):
+        recorder, token = us.start_recording()
+        try:
+            assert isinstance(recorder, UsageRecorder)
+            assert recorder.events == []
+            assert current_usage.get() is recorder
+        finally:
+            current_usage.reset(token)
+        # After reset, the recorder is no longer active
+        assert current_usage.get() is not recorder
+
+
+class TestPersistRecorder:
+    @pytest.mark.asyncio
+    async def test_skips_when_recorder_empty(self, monkeypatch):
+        fake_insert = AsyncMock()
+        monkeypatch.setattr(
+            us.TaskUsageRepository, "insert_many", fake_insert
+        )
+        count = await us.persist_recorder(
+            db=object(), recorder=UsageRecorder(), task_id="t1", user_id="u1"
+        )
+        assert count == 0
+        fake_insert.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_writes_all_events(self, monkeypatch):
+        fake_insert = AsyncMock()
+        monkeypatch.setattr(us.TaskUsageRepository, "insert_many", fake_insert)
+        recorder = UsageRecorder(events=[
+            UsageEvent(service="llm", model="a", input_tokens=100, output_tokens=50, cost_usd=0.01),
+            UsageEvent(service="assemblyai", audio_seconds=30.0, cost_usd=0.003),
+        ])
+        count = await us.persist_recorder(
+            db="db", recorder=recorder, task_id="t42", user_id="u7"
+        )
+        assert count == 2
+        fake_insert.assert_awaited_once()
+        call_args = fake_insert.await_args
+        # positional: (db, task_id, user_id, payload)
+        assert call_args.args[1] == "t42"
+        assert call_args.args[2] == "u7"
+        payload = call_args.args[3]
+        assert len(payload) == 2
+        # Converted to dicts (dataclass asdict)
+        assert payload[0]["service"] == "llm"
+        assert payload[0]["input_tokens"] == 100
+
+
+class TestMonthlySummary:
+    @pytest.mark.asyncio
+    async def test_sends_month_start_and_decorates_window(self, monkeypatch):
+        fake_summary = AsyncMock(return_value={"cost_usd": 1.23})
+        monkeypatch.setattr(us.TaskUsageRepository, "summary_since", fake_summary)
+
+        frozen = datetime(2026, 4, 15, 12, 30, 0, tzinfo=timezone.utc)
+        result = await us.monthly_summary(db="db", now=frozen)
+        assert result["window"] == "month_to_date"
+        assert result["window_start"].startswith("2026-04-01")
+        assert result["window_end"].startswith("2026-04-15")
+        assert result["cost_usd"] == 1.23
+        # summary_since called with month-start datetime (day=1, hour=0)
+        start_arg = fake_summary.await_args.args[1]
+        assert start_arg.day == 1
+        assert start_arg.hour == 0
+        assert start_arg.minute == 0
+
+
+class TestTrailingSummary:
+    @pytest.mark.asyncio
+    async def test_subtracts_days(self, monkeypatch):
+        fake = AsyncMock(return_value={"cost_usd": 0})
+        monkeypatch.setattr(us.TaskUsageRepository, "summary_since", fake)
+
+        frozen = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        result = await us.trailing_summary(db="db", days=7, now=frozen)
+        assert result["window"] == "last_7_days"
+        assert result["window_start"].startswith("2026-04-13")
+        since = fake.await_args.args[1]
+        assert since == frozen - timedelta(days=7)
+
+
+class TestRecentTasks:
+    @pytest.mark.asyncio
+    async def test_uses_default_days_and_limit(self, monkeypatch):
+        fake = AsyncMock(return_value=[{"task_id": "a"}])
+        monkeypatch.setattr(us.TaskUsageRepository, "recent_tasks", fake)
+
+        frozen = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        result = await us.recent_tasks(db="db", now=frozen)
+        assert result == [{"task_id": "a"}]
+        # call_args: db, since, limit=limit
+        call = fake.await_args
+        assert call.args[1] == frozen - timedelta(days=30)
+        assert call.kwargs["limit"] == 20
+
+    @pytest.mark.asyncio
+    async def test_honors_custom_params(self, monkeypatch):
+        fake = AsyncMock(return_value=[])
+        monkeypatch.setattr(us.TaskUsageRepository, "recent_tasks", fake)
+        frozen = datetime(2026, 4, 20, tzinfo=timezone.utc)
+        await us.recent_tasks(db="db", days=3, limit=5, now=frozen)
+        call = fake.await_args
+        assert call.args[1] == frozen - timedelta(days=3)
+        assert call.kwargs["limit"] == 5
+
+
+class TestTaskBreakdown:
+    @pytest.mark.asyncio
+    async def test_aggregates_totals(self, monkeypatch):
+        events = [
+            {"cost_usd": 0.1, "audio_seconds": 10, "input_tokens": 100, "output_tokens": 50},
+            {"cost_usd": 0.2, "audio_seconds": 20, "input_tokens": 200, "output_tokens": 150},
+        ]
+        fake = AsyncMock(return_value=events)
+        monkeypatch.setattr(us.TaskUsageRepository, "list_events_for_task", fake)
+
+        result = await us.task_breakdown(db="db", task_id="t1")
+        assert result["task_id"] == "t1"
+        assert result["events"] is events
+        totals = result["totals"]
+        assert totals["cost_usd"] == pytest.approx(0.3)
+        assert totals["audio_seconds"] == 30
+        assert totals["input_tokens"] == 300
+        assert totals["output_tokens"] == 200
+        assert totals["event_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_events_returns_zero_totals(self, monkeypatch):
+        monkeypatch.setattr(
+            us.TaskUsageRepository, "list_events_for_task", AsyncMock(return_value=[])
+        )
+        result = await us.task_breakdown(db="db", task_id="t2")
+        assert result["totals"]["event_count"] == 0
+        assert result["totals"]["cost_usd"] == 0

--- a/backend/tests/unit/test_video_encoder.py
+++ b/backend/tests/unit/test_video_encoder.py
@@ -1,0 +1,53 @@
+"""Tests for ``src/_video_encoder.py``."""
+
+import pytest
+
+from src._video_encoder import VideoProcessor
+
+
+class TestVideoProcessorInit:
+    def test_stores_font_meta(self):
+        proc = VideoProcessor(
+            font_family="TikTokSans-Regular",
+            font_size=30,
+            font_color="#FFEE00",
+            bold=True,
+        )
+        assert proc.font_family == "TikTokSans-Regular"
+        assert proc.font_size == 30
+        assert proc.font_color == "#FFEE00"
+        assert proc.bold is True
+        assert proc.italic is False
+
+    def test_falls_back_when_font_missing(self):
+        # A made-up font name should fall back through registry without raising.
+        proc = VideoProcessor(font_family="definitely-not-a-real-font-xyz")
+        # font_path is a string — empty allowed if no fallback resolved either
+        assert isinstance(proc.font_path, str)
+
+    def test_coerces_bold_italic_to_bool(self):
+        proc = VideoProcessor(bold=1, italic="truthy")  # type: ignore[arg-type]
+        assert proc.bold is True
+        assert proc.italic is True
+
+
+class TestEncodingSettings:
+    def test_high_quality_defaults(self):
+        settings = VideoProcessor().get_optimal_encoding_settings("high")
+        assert settings["codec"] == "libx264"
+        assert settings["audio_codec"] == "aac"
+        assert settings["audio_bitrate"] == "256k"
+        assert settings["preset"] == "slow"
+        assert "-crf" in settings["ffmpeg_params"]
+        assert "18" in settings["ffmpeg_params"]
+
+    def test_medium_quality(self):
+        settings = VideoProcessor().get_optimal_encoding_settings("medium")
+        assert settings["preset"] == "fast"
+        assert settings["bitrate"] == "4000k"
+        assert "23" in settings["ffmpeg_params"]
+
+    def test_unknown_quality_falls_back_to_high(self):
+        unknown = VideoProcessor().get_optimal_encoding_settings("ultra-premium-bogus")
+        high = VideoProcessor().get_optimal_encoding_settings("high")
+        assert unknown == high

--- a/backend/tests/unit/test_video_helpers.py
+++ b/backend/tests/unit/test_video_helpers.py
@@ -1,0 +1,150 @@
+"""Tests for pure helpers in ``src/_video_helpers.py``."""
+
+import pytest
+
+from src._video_helpers import (
+    _chunk_words_by_speaker,
+    format_ms_to_timestamp,
+    get_safe_vertical_position,
+    get_scaled_font_size,
+    get_subtitle_max_width,
+    get_words_in_range,
+    parse_timestamp_to_seconds,
+    round_to_even,
+)
+
+
+class TestFormatMsToTimestamp:
+    @pytest.mark.parametrize(
+        "ms,expected",
+        [
+            (0, "00:00"),
+            (1000, "00:01"),
+            (59_000, "00:59"),
+            (60_000, "01:00"),
+            (125_500, "02:05"),  # truncates to whole seconds
+        ],
+    )
+    def test_formats(self, ms, expected):
+        assert format_ms_to_timestamp(ms) == expected
+
+
+class TestRoundToEven:
+    @pytest.mark.parametrize("value,expected", [(0, 0), (1, 0), (2, 2), (3, 2), (1081, 1080)])
+    def test_rounds_down_to_even(self, value, expected):
+        assert round_to_even(value) == expected
+
+
+class TestGetScaledFontSize:
+    def test_scales_linearly_with_width(self):
+        # reference width is 720
+        assert get_scaled_font_size(24, 720) == 24
+        assert get_scaled_font_size(24, 1440) == 48
+
+    def test_clamps_to_minimum(self):
+        assert get_scaled_font_size(10, 100) == 24
+
+    def test_clamps_to_maximum(self):
+        assert get_scaled_font_size(48, 4000) == 64
+
+
+class TestGetSubtitleMaxWidth:
+    def test_applies_horizontal_padding(self):
+        # 6% padding of 1000 = 60, min 40 → 60 each side
+        assert get_subtitle_max_width(1000) == 1000 - (60 * 2)
+
+    def test_respects_minimum_padding(self):
+        # 6% of 300 = 18, min 40 → 40 each side
+        assert get_subtitle_max_width(300) == 300 - (40 * 2)
+
+    def test_respects_minimum_width(self):
+        assert get_subtitle_max_width(100) == 200
+
+
+class TestGetSafeVerticalPosition:
+    def test_respects_top_safe_area(self):
+        pos = get_safe_vertical_position(video_height=1920, text_height=60, position_y=0.0)
+        assert pos >= max(40, int(1920 * 0.05))
+
+    def test_respects_bottom_safe_area(self):
+        pos = get_safe_vertical_position(video_height=1920, text_height=60, position_y=1.0)
+        max_y = 1920 - max(120, int(1920 * 0.10)) - 60
+        assert pos <= max_y
+
+    def test_centered_target(self):
+        pos = get_safe_vertical_position(video_height=1000, text_height=100, position_y=0.5)
+        assert 400 <= pos <= 600
+
+
+class TestParseTimestampToSeconds:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("00:30", 30),
+            ("01:15", 75),
+            ("00:01:30", 90),
+            ("1:02:03", 3723),
+            ("12.5", 12.5),
+        ],
+    )
+    def test_valid_inputs(self, value, expected):
+        assert parse_timestamp_to_seconds(value) == expected
+
+    def test_invalid_returns_zero(self):
+        assert parse_timestamp_to_seconds("not-a-time") == 0.0
+
+    def test_handles_whitespace(self):
+        assert parse_timestamp_to_seconds("  00:30  ") == 30
+
+
+class TestGetWordsInRange:
+    def test_empty_transcript(self):
+        assert get_words_in_range({}, 0, 10) == []
+        assert get_words_in_range({"words": []}, 0, 10) == []
+
+    def test_filters_to_range_and_rebases_to_clip_start(self):
+        transcript = {
+            "words": [
+                {"text": "alpha", "start": 0, "end": 500},
+                {"text": "beta", "start": 1000, "end": 1500},
+                {"text": "gamma", "start": 2000, "end": 2500},
+            ]
+        }
+        words = get_words_in_range(transcript, clip_start=1.0, clip_end=2.5)
+        assert [w["text"] for w in words] == ["beta", "gamma"]
+        # beta starts at 1000ms in absolute, clip starts at 1000ms → rebased to 0
+        assert words[0]["start"] == pytest.approx(0.0)
+        assert words[0]["end"] == pytest.approx(0.5)
+
+    def test_confidence_defaults_to_one(self):
+        transcript = {"words": [{"text": "x", "start": 0, "end": 500}]}
+        word = get_words_in_range(transcript, 0, 1)[0]
+        assert word["confidence"] == 1.0
+        assert word["speaker"] is None
+
+
+class TestChunkWordsBySpeaker:
+    def _w(self, text, speaker=None):
+        return {"text": text, "speaker": speaker}
+
+    def test_empty(self):
+        assert _chunk_words_by_speaker([], 3) == []
+
+    def test_zero_max_returns_empty(self):
+        assert _chunk_words_by_speaker([self._w("x")], 0) == []
+
+    def test_chunks_by_size(self):
+        words = [self._w(str(i)) for i in range(7)]
+        groups = _chunk_words_by_speaker(words, max_per_group=3)
+        assert [len(g) for g in groups] == [3, 3, 1]
+
+    def test_splits_on_speaker_change(self):
+        words = [
+            self._w("hi", "A"),
+            self._w("there", "A"),
+            self._w("greetings", "B"),
+        ]
+        groups = _chunk_words_by_speaker(words, max_per_group=10)
+        assert len(groups) == 2
+        assert [w["text"] for w in groups[0]] == ["hi", "there"]
+        assert [w["text"] for w in groups[1]] == ["greetings"]

--- a/backend/tests/unit/test_video_transitions_listing.py
+++ b/backend/tests/unit/test_video_transitions_listing.py
@@ -1,0 +1,39 @@
+"""Tests for the lightweight listing helper in ``_video_transitions``.
+
+The heavier ``apply_transition_effect`` path is already exercised by
+``tests/unit/test_video_utils_effects.py``; this file focuses on the
+filesystem-based ``get_available_transitions`` listing.
+"""
+
+from unittest.mock import patch
+
+from src._video_transitions import get_available_transitions
+
+
+class TestGetAvailableTransitions:
+    def test_missing_dir_returns_empty(self, tmp_path, monkeypatch):
+        import src._video_transitions as vt
+
+        fake_file = tmp_path / "nothere" / "_video_transitions.py"
+        # Point __file__ to a location whose parent.parent / "transitions" does not exist.
+        monkeypatch.setattr(vt, "__file__", str(fake_file))
+        assert get_available_transitions() == []
+
+    def test_lists_mp4_files(self, tmp_path, monkeypatch):
+        """Wire the module's ``__file__`` so transitions/ sits under tmp_path."""
+        import src._video_transitions as vt
+
+        transitions_dir = tmp_path / "transitions"
+        transitions_dir.mkdir()
+        (transitions_dir / "fade.mp4").write_bytes(b"\x00")
+        (transitions_dir / "swipe.mp4").write_bytes(b"\x00")
+        (transitions_dir / "notes.txt").write_text("ignore me")
+
+        # __file__ lives one level deeper than the transitions dir in production.
+        fake_file = tmp_path / "src" / "_video_transitions.py"
+        (tmp_path / "src").mkdir()
+        monkeypatch.setattr(vt, "__file__", str(fake_file))
+
+        result = get_available_transitions()
+        names = sorted(str(p).split("\\")[-1].split("/")[-1] for p in result)
+        assert names == ["fade.mp4", "swipe.mp4"]

--- a/backend/tests/unit/test_workers.py
+++ b/backend/tests/unit/test_workers.py
@@ -1,0 +1,302 @@
+"""Tests for ``src/workers/job_queue.py`` and ``src/workers/progress.py``.
+
+Redis + arq clients are fully mocked via ``AsyncMock``/``MagicMock`` so tests
+do not touch a real Redis instance.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.workers import job_queue as jq
+from src.workers.progress import ProgressTracker
+
+
+# ---------------------------------------------------------------------------
+# job_queue
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool():
+    """Ensure each test starts with a fresh JobQueue._pool."""
+    jq.JobQueue._pool = None
+    yield
+    jq.JobQueue._pool = None
+
+
+class TestRedisSettings:
+    def test_pulls_from_config(self, monkeypatch):
+        class FakeCfg:
+            redis_host = "redis-host"
+            redis_port = 6380
+            redis_password = "s3cret"
+
+        monkeypatch.setattr(jq, "get_config", lambda: FakeCfg())
+        settings = jq._get_redis_settings()
+        assert settings.host == "redis-host"
+        assert settings.port == 6380
+        assert settings.password == "s3cret"
+        assert settings.database == 0
+
+
+class TestJobQueuePool:
+    @pytest.mark.asyncio
+    async def test_get_pool_creates_and_caches(self, monkeypatch):
+        fake_pool = AsyncMock(name="fake_pool")
+        create_mock = AsyncMock(return_value=fake_pool)
+        monkeypatch.setattr(jq, "create_pool", create_mock)
+
+        first = await jq.JobQueue.get_pool()
+        second = await jq.JobQueue.get_pool()
+        assert first is fake_pool
+        assert second is fake_pool
+        # Cached after first call — create_pool only invoked once
+        create_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_close_pool_is_idempotent(self, monkeypatch):
+        fake_pool = AsyncMock(name="fake_pool")
+        fake_pool.close = AsyncMock()
+        jq.JobQueue._pool = fake_pool
+
+        await jq.JobQueue.close_pool()
+        fake_pool.close.assert_awaited_once()
+        assert jq.JobQueue._pool is None
+
+        # Second call is a no-op
+        await jq.JobQueue.close_pool()
+        fake_pool.close.assert_awaited_once()
+
+
+class TestEnqueueJob:
+    @pytest.mark.asyncio
+    async def test_enqueue_job_returns_id_and_uses_default_queue(self, monkeypatch):
+        fake_job = MagicMock()
+        fake_job.job_id = "job-xyz"
+        fake_pool = MagicMock()
+        fake_pool.enqueue_job = AsyncMock(return_value=fake_job)
+
+        async def fake_create_pool(_settings):
+            return fake_pool
+
+        monkeypatch.setattr(jq, "create_pool", fake_create_pool)
+
+        job_id = await jq.JobQueue.enqueue_job("process_task", 1, 2, foo="bar")
+        assert job_id == "job-xyz"
+        call = fake_pool.enqueue_job.await_args
+        assert call.args[0] == "process_task"
+        assert call.args[1:] == (1, 2)
+        assert call.kwargs["_queue_name"] == jq.DEFAULT_QUEUE_NAME
+        assert call.kwargs["foo"] == "bar"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_custom_queue_name(self, monkeypatch):
+        fake_job = MagicMock()
+        fake_job.job_id = "j1"
+        fake_pool = MagicMock()
+        fake_pool.enqueue_job = AsyncMock(return_value=fake_job)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        await jq.JobQueue.enqueue_job("fn", _queue_name="custom-q")
+        call = fake_pool.enqueue_job.await_args
+        assert call.kwargs["_queue_name"] == "custom-q"
+
+    @pytest.mark.asyncio
+    async def test_enqueue_job_returns_none_raises(self, monkeypatch):
+        fake_pool = MagicMock()
+        fake_pool.enqueue_job = AsyncMock(return_value=None)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        with pytest.raises(RuntimeError, match="Failed to enqueue"):
+            await jq.JobQueue.enqueue_job("fn")
+
+    @pytest.mark.asyncio
+    async def test_enqueue_job_missing_id_raises(self, monkeypatch):
+        # arq can return a Job-like object without a job_id in edge cases.
+        fake_job = MagicMock()
+        fake_job.job_id = None
+        fake_pool = MagicMock()
+        fake_pool.enqueue_job = AsyncMock(return_value=fake_job)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        with pytest.raises(RuntimeError, match="missing job ID"):
+            await jq.JobQueue.enqueue_job("fn")
+
+
+class TestEnqueueProcessingJob:
+    @pytest.mark.asyncio
+    async def test_uses_default_queue_regardless_of_mode(self, monkeypatch):
+        fake_job = MagicMock()
+        fake_job.job_id = "jx"
+        fake_pool = MagicMock()
+        fake_pool.enqueue_job = AsyncMock(return_value=fake_job)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        await jq.JobQueue.enqueue_processing_job("fn", "fast", 1, 2)
+        call = fake_pool.enqueue_job.await_args
+        assert call.kwargs["_queue_name"] == jq.DEFAULT_QUEUE_NAME
+
+
+class TestJobLookups:
+    @pytest.mark.asyncio
+    async def test_get_job_result_returns_result(self, monkeypatch):
+        fake_job = MagicMock()
+        fake_job.result = AsyncMock(return_value="ok")
+        fake_pool = MagicMock()
+        fake_pool.job = AsyncMock(return_value=fake_job)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        assert await jq.JobQueue.get_job_result("j1") == "ok"
+
+    @pytest.mark.asyncio
+    async def test_get_job_result_none_when_missing(self, monkeypatch):
+        fake_pool = MagicMock()
+        fake_pool.job = AsyncMock(return_value=None)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        assert await jq.JobQueue.get_job_result("nope") is None
+
+    @pytest.mark.asyncio
+    async def test_get_job_status_returns_status(self, monkeypatch):
+        fake_job = MagicMock()
+        fake_job.status = AsyncMock(return_value="complete")
+        fake_pool = MagicMock()
+        fake_pool.job = AsyncMock(return_value=fake_job)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        assert await jq.JobQueue.get_job_status("j1") == "complete"
+
+    @pytest.mark.asyncio
+    async def test_get_job_status_none_when_missing(self, monkeypatch):
+        fake_pool = MagicMock()
+        fake_pool.job = AsyncMock(return_value=None)
+        monkeypatch.setattr(jq, "create_pool", AsyncMock(return_value=fake_pool))
+
+        assert await jq.JobQueue.get_job_status("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# ProgressTracker
+# ---------------------------------------------------------------------------
+
+
+def _fake_redis():
+    redis = MagicMock()
+    redis.setex = AsyncMock()
+    redis.publish = AsyncMock()
+    redis.get = AsyncMock()
+    return redis
+
+
+class TestProgressTrackerUpdate:
+    @pytest.mark.asyncio
+    async def test_writes_setex_and_publishes(self):
+        redis = _fake_redis()
+        tracker = ProgressTracker(redis, "task-1")
+        await tracker.update(50, "Processing", status="processing")
+
+        assert redis.setex.await_count == 1
+        setex_args = redis.setex.await_args.args
+        assert setex_args[0] == "progress:task-1"
+        assert setex_args[1] == 3600
+        payload = json.loads(setex_args[2])
+        assert payload["task_id"] == "task-1"
+        assert payload["progress"] == 50
+        assert payload["message"] == "Processing"
+        assert payload["status"] == "processing"
+
+        # Publish should mirror the same payload on the channel
+        publish_args = redis.publish.await_args.args
+        assert publish_args[0] == "progress:task-1"
+        assert json.loads(publish_args[1]) == payload
+
+    @pytest.mark.asyncio
+    async def test_complete_sends_100_percent(self):
+        redis = _fake_redis()
+        tracker = ProgressTracker(redis, "t")
+        await tracker.complete()
+        payload = json.loads(redis.setex.await_args.args[2])
+        assert payload["progress"] == 100
+        assert payload["status"] == "completed"
+
+    @pytest.mark.asyncio
+    async def test_error_sends_zero_with_status(self):
+        redis = _fake_redis()
+        tracker = ProgressTracker(redis, "t")
+        await tracker.error("boom")
+        payload = json.loads(redis.setex.await_args.args[2])
+        assert payload["progress"] == 0
+        assert payload["status"] == "error"
+        assert payload["message"] == "boom"
+
+
+class TestProgressTrackerGet:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_empty(self):
+        redis = _fake_redis()
+        redis.get = AsyncMock(return_value=None)
+        tracker = ProgressTracker(redis, "t")
+        assert await tracker.get() is None
+
+    @pytest.mark.asyncio
+    async def test_decodes_json(self):
+        redis = _fake_redis()
+        redis.get = AsyncMock(return_value=json.dumps({"progress": 42}))
+        tracker = ProgressTracker(redis, "t")
+        result = await tracker.get()
+        assert result == {"progress": 42}
+
+
+class TestProgressTrackerClipReady:
+    @pytest.mark.asyncio
+    async def test_publishes_clip_ready_event(self):
+        redis = _fake_redis()
+        tracker = ProgressTracker(redis, "t")
+        await tracker.clip_ready(
+            clip_index=2,
+            total_clips=5,
+            clip_data={"id": "c1", "path": "/tmp/c1.mp4"},
+        )
+        publish = redis.publish.await_args
+        assert publish.args[0] == "progress:t"
+        payload = json.loads(publish.args[1])
+        assert payload["event_type"] == "clip_ready"
+        assert payload["clip_index"] == 2
+        assert payload["total_clips"] == 5
+        assert payload["clip"]["id"] == "c1"
+
+
+class TestProgressTrackerSubscribe:
+    @pytest.mark.asyncio
+    async def test_yields_messages_and_cleans_up(self):
+        # Build a fake pubsub object with an async listen() generator.
+        async def fake_listen():
+            yield {"type": "subscribe", "data": "ignored"}
+            yield {"type": "message", "data": json.dumps({"progress": 10})}
+            yield {"type": "message", "data": json.dumps({"progress": 20})}
+
+        fake_pubsub = MagicMock()
+        fake_pubsub.subscribe = AsyncMock()
+        fake_pubsub.unsubscribe = AsyncMock()
+        fake_pubsub.close = AsyncMock()
+        fake_pubsub.listen = fake_listen
+
+        redis = _fake_redis()
+        redis.pubsub = MagicMock(return_value=fake_pubsub)
+
+        gen = ProgressTracker.subscribe_to_progress(redis, "t1")
+        received = []
+        try:
+            async for item in gen:
+                received.append(item)
+                if len(received) == 2:
+                    break
+        finally:
+            await gen.aclose()
+
+        assert received == [{"progress": 10}, {"progress": 20}]
+        fake_pubsub.subscribe.assert_awaited_once_with("progress:t1")
+        fake_pubsub.unsubscribe.assert_awaited_once_with("progress:t1")
+        fake_pubsub.close.assert_awaited_once()

--- a/backend/tests/unit/test_youtube_downloader.py
+++ b/backend/tests/unit/test_youtube_downloader.py
@@ -1,0 +1,51 @@
+"""Tests for ``src/_youtube_downloader.py``."""
+
+import pytest
+
+from src._youtube_downloader import YouTubeDownloader
+
+
+class TestYouTubeDownloader:
+    def test_initializes_temp_dir(self, tmp_path, monkeypatch):
+        from src import config as config_module
+
+        class FakeCfg:
+            temp_dir = str(tmp_path / "downloads")
+
+        monkeypatch.setattr(config_module, "get_config", lambda: FakeCfg())
+        # _youtube_downloader.get_config is imported at module load; re-patch
+        from src import _youtube_downloader
+
+        monkeypatch.setattr(_youtube_downloader, "get_config", lambda: FakeCfg())
+
+        dl = YouTubeDownloader()
+        assert dl.temp_dir.exists()
+        assert dl.temp_dir.name == "downloads"
+
+    def test_optimal_download_options_has_expected_keys(self, tmp_path, monkeypatch):
+        from src import _youtube_downloader
+
+        class FakeCfg:
+            temp_dir = str(tmp_path)
+
+        monkeypatch.setattr(_youtube_downloader, "get_config", lambda: FakeCfg())
+        dl = YouTubeDownloader()
+
+        opts = dl.get_optimal_download_options("abc123")
+        assert "bestvideo" in opts["format"]
+        assert opts["merge_output_format"] == "mp4"
+        assert opts["quiet"] is True
+        assert opts["noplaylist"] is True
+        assert opts["outtmpl"].endswith("abc123.%(ext)s")
+
+    def test_output_template_includes_video_id(self, tmp_path, monkeypatch):
+        from src import _youtube_downloader
+
+        class FakeCfg:
+            temp_dir = str(tmp_path)
+
+        monkeypatch.setattr(_youtube_downloader, "get_config", lambda: FakeCfg())
+        dl = YouTubeDownloader()
+
+        opts = dl.get_optimal_download_options("zzz999")
+        assert "zzz999" in opts["outtmpl"]

--- a/backend/tests/unit/test_youtube_io.py
+++ b/backend/tests/unit/test_youtube_io.py
@@ -1,0 +1,110 @@
+"""Tests for ``src/_youtube_io.py``."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src._youtube_io import (
+    _build_info_options,
+    _empty_video_info,
+    _get_local_video_dimensions,
+    _remove_cached_downloads,
+)
+
+
+class TestBuildInfoOptions:
+    def test_has_required_keys(self):
+        opts = _build_info_options()
+        assert opts["quiet"] is True
+        assert opts["skip_download"] is True
+        assert opts["no_warnings"] is True
+        assert "http_headers" in opts
+        assert "User-Agent" in opts["http_headers"]
+
+    def test_socket_timeout_sensible(self):
+        assert _build_info_options()["socket_timeout"] >= 1
+
+
+class TestEmptyVideoInfo:
+    def test_default_shape(self):
+        info = _empty_video_info()
+        assert info["id"] is None
+        assert info["title"] is None
+        assert info["description"] == ""
+        assert info["duration"] is None
+
+    def test_preserves_video_id(self):
+        info = _empty_video_info("abc123")
+        assert info["id"] == "abc123"
+
+    def test_all_numeric_fields_none(self):
+        info = _empty_video_info()
+        for k in ("duration", "view_count", "like_count", "fps", "filesize"):
+            assert info[k] is None
+
+
+class TestGetLocalVideoDimensions:
+    def test_returns_zero_on_error(self, tmp_path):
+        missing = tmp_path / "missing.mp4"
+        # ffprobe is not guaranteed to exist in the test env, and even if it
+        # does, a non-existent file should make it fail. Either path returns
+        # (0, 0) by design.
+        assert _get_local_video_dimensions(missing) == (0, 0)
+
+    def test_parses_ffprobe_output(self, monkeypatch):
+        class FakeResult:
+            stdout = "1920x1080\n"
+
+        def fake_run(*args, **kwargs):
+            return FakeResult()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert _get_local_video_dimensions(Path("anything.mp4")) == (1920, 1080)
+
+    def test_malformed_output_returns_zero(self, monkeypatch):
+        class FakeResult:
+            stdout = "garbage"
+
+        monkeypatch.setattr(subprocess, "run", lambda *a, **k: FakeResult())
+        assert _get_local_video_dimensions(Path("x.mp4")) == (0, 0)
+
+
+class TestRemoveCachedDownloads:
+    def test_noop_when_no_matches(self, tmp_path):
+        _remove_cached_downloads(tmp_path, "missing-id")
+        # Just asserting it doesn't raise.
+
+    def test_removes_video_files(self, tmp_path):
+        video_id = "abc123"
+        targets = [
+            tmp_path / f"{video_id}.mp4",
+            tmp_path / f"{video_id}.mkv",
+            tmp_path / f"{video_id}.webm",
+        ]
+        keep = tmp_path / f"{video_id}.txt"
+        for p in targets + [keep]:
+            p.write_bytes(b"\x00")
+
+        _remove_cached_downloads(tmp_path, video_id)
+
+        for p in targets:
+            assert not p.exists(), f"{p.name} should have been removed"
+        assert keep.exists(), "non-video files should not be removed"
+
+    def test_is_resilient_to_unlink_errors(self, tmp_path, monkeypatch):
+        video_id = "abc123"
+        f = tmp_path / f"{video_id}.mp4"
+        f.write_bytes(b"\x00")
+
+        original_unlink = Path.unlink
+
+        def flaky_unlink(self, *args, **kwargs):
+            if self == f:
+                raise PermissionError("locked")
+            return original_unlink(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "unlink", flaky_unlink)
+        # Must not raise
+        _remove_cached_downloads(tmp_path, video_id)

--- a/backend/tests/unit/test_youtube_parsers.py
+++ b/backend/tests/unit/test_youtube_parsers.py
@@ -1,0 +1,140 @@
+"""Tests for pure parsers in ``src/_youtube_parsers.py``."""
+
+import pytest
+
+from src._youtube_parsers import (
+    _normalize_upload_date,
+    _parse_iso8601_duration_to_seconds,
+    _parse_optional_int,
+    _pick_best_thumbnail,
+    get_youtube_video_id,
+    validate_youtube_url,
+)
+
+
+class TestParseIso8601Duration:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("PT0S", 0),
+            ("PT30S", 30),
+            ("PT1M", 60),
+            ("PT1M30S", 90),
+            ("PT1H", 3600),
+            ("PT1H2M3S", 3723),
+            ("P1DT2H3M4S", 86400 + 7200 + 180 + 4),
+            ("PT", 0),
+        ],
+    )
+    def test_valid(self, value, expected):
+        assert _parse_iso8601_duration_to_seconds(value) == expected
+
+    @pytest.mark.parametrize("value", ["garbage", "1H2M", ""])
+    def test_invalid_raises(self, value):
+        with pytest.raises(ValueError):
+            _parse_iso8601_duration_to_seconds(value)
+
+    def test_bare_p_parses_to_zero(self):
+        # "P" is technically valid ISO-8601 syntax (all components optional).
+        assert _parse_iso8601_duration_to_seconds("P") == 0
+
+
+class TestPickBestThumbnail:
+    def test_none_returns_none(self):
+        assert _pick_best_thumbnail(None) is None
+        assert _pick_best_thumbnail({}) is None
+
+    def test_prefers_maxres(self):
+        thumbnails = {
+            "default": {"url": "d"},
+            "medium": {"url": "m"},
+            "maxres": {"url": "mr"},
+        }
+        assert _pick_best_thumbnail(thumbnails) == "mr"
+
+    def test_falls_through_tiers(self):
+        assert _pick_best_thumbnail({"high": {"url": "h"}}) == "h"
+        assert _pick_best_thumbnail({"medium": {"url": "m"}}) == "m"
+        assert _pick_best_thumbnail({"default": {"url": "d"}}) == "d"
+
+    def test_falls_back_to_any_entry(self):
+        thumbnails = {"weirdkey": {"url": "w"}}
+        assert _pick_best_thumbnail(thumbnails) == "w"
+
+    def test_skips_entries_without_url(self):
+        thumbnails = {"default": {}, "medium": {"url": "m"}}
+        assert _pick_best_thumbnail(thumbnails) == "m"
+
+
+class TestNormalizeUploadDate:
+    def test_parses_iso_with_z(self):
+        assert _normalize_upload_date("2024-03-15T10:30:00Z") == "20240315"
+
+    def test_parses_iso_with_offset(self):
+        assert _normalize_upload_date("2024-03-15T10:30:00+00:00") == "20240315"
+
+    def test_none_returns_none(self):
+        assert _normalize_upload_date(None) is None
+        assert _normalize_upload_date("") is None
+
+    def test_invalid_returns_none(self):
+        assert _normalize_upload_date("not-a-date") is None
+
+
+class TestParseOptionalInt:
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("42", 42),
+            (42, 42),
+            ("0", 0),
+            (None, None),
+            ("", None),
+            ("abc", None),
+            ([1, 2], None),
+        ],
+    )
+    def test_values(self, value, expected):
+        assert _parse_optional_int(value) == expected
+
+
+class TestGetYoutubeVideoId:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+            ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+            ("https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+            ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+            ("https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+            ("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s", "dQw4w9WgXcQ"),
+        ],
+    )
+    def test_valid_urls(self, url, expected):
+        assert get_youtube_video_id(url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "",
+            "   ",
+            "https://example.com/watch?v=dQw4w9WgXcQ",
+            "not a url",
+            None,
+        ],
+    )
+    def test_invalid_returns_none(self, url):
+        assert get_youtube_video_id(url) is None
+
+    def test_trims_whitespace(self):
+        assert (
+            get_youtube_video_id("  https://youtu.be/dQw4w9WgXcQ  ") == "dQw4w9WgXcQ"
+        )
+
+
+class TestValidateYoutubeUrl:
+    def test_valid(self):
+        assert validate_youtube_url("https://youtu.be/dQw4w9WgXcQ") is True
+
+    def test_invalid(self):
+        assert validate_youtube_url("https://example.com") is False

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,8 @@ Responsibilities:
 Important services:
 
 - `task_service.py`
+  - Orchestration. Clip editing in `_clip_edit_mixin.py`, completion-email
+    in `_task_notification_mixin.py`, pure helpers in `_task_helpers.py`
 - `video_service.py`
 - `billing_service.py`
 - `subscription_email_service.py`
@@ -190,7 +192,17 @@ Important backend modules:
 - `ai.py`
   - Prompting and structured LLM output
 - `video_utils.py`
-  - Rendering, cropping, and subtitle logic
+  - Thin entry point. Rendering/cropping/subtitle logic lives in split
+    submodules: `_video_encoder.py` (encoder + font resolver),
+    `_video_helpers.py` (timestamp/sizing/word helpers),
+    `_video_transitions.py` (transition effects + listing),
+    `_video_face.py`, `_video_broll.py`, `_video_subtitles.py`,
+    `_video_transcript.py`
+- `youtube_utils.py`
+  - YouTube metadata + download entry point. Split submodules:
+    `_youtube_parsers.py` (URL/ISO-8601 parsers),
+    `_youtube_io.py` (ffprobe + cache helpers),
+    `_youtube_downloader.py` (yt-dlp option presets)
 - `clip_editor.py`
   - Post-generation clip edits and exports
 - `caption_templates.py`
@@ -198,9 +210,14 @@ Important backend modules:
 - `broll.py`
   - Optional Pexels integration
 - `font_registry.py`
-  - Font discovery and registration
+  - Font discovery and registration. `find_font_path` guards against
+    path-traversal payloads via `_is_path_inside`
 - `observability.py`
   - Metrics and timing helpers
+- `api/routes/tasks/schemas.py`
+  - Pydantic request schemas for `/tasks/*` endpoints (create, settings,
+    clip trim/split/merge/captions/regenerate). Invalid input returns 422
+    before reaching the service layer
 
 ## Frontend Architecture
 


### PR DESCRIPTION
## Summary

Three self-contained backend improvements, each in its own commit so they can be reviewed/reverted independently.

### 1. Module size reductions (commit 1c83bd4)
Three files exceeded the project's 500-line soft limit. Split into smaller modules while keeping public API + `patch(\"src.*.*\")` test targets intact via top-level re-exports:

| File | Before | After |
|---|---|---|
| `backend/src/video_utils.py` | 714 | **388** |
| `backend/src/youtube_utils.py` | 667 | **423** |
| `backend/src/services/task_service.py` | 562 | **482** |

New submodules: `_video_encoder`, `_video_helpers`, `_video_transitions`, `_youtube_parsers`, `_youtube_io`, `_youtube_downloader`, `services/_task_helpers`, `services/_task_notification_mixin`.

### 2. Test coverage 38% → 49% (commit 1132054)
- 20 new unit test files covering pure helpers (pricing, captions, config, observability, parsers, etc.) and the newly split submodules
- 3 integration test files for `/tasks/*` endpoints (25 scenarios: happy path, 404, 403, auth, validation)
- 10 modules now at 100% line coverage
- Test count: **51 → 413 passed** (0 failures, 0 regressions)
- `tests/conftest.py` `FakeQueueAdapter` now accepts `**kwargs` to match current service-layer calls

### 3. Security hardening (commit 6cc0c16)
- **Path traversal defense** in `font_registry.find_font_path`: rejects `../`, `/`, `\`, `\x00` tokens and verifies resolved candidate is under `search_dir` (new `_is_path_inside` helper). Covers the `GET /fonts/{font_name}` route.
- **Pydantic request schemas** for all five `/tasks/{id}/clips/*` routes (trim / split / merge / captions / regenerate) — replaces hand-rolled `payload = await request.json()` with `ge`/`gt`/`min_length`/`Literal[...]` constraints so invalid input returns 422 instead of reaching the service layer.
- 17 regression tests for the new defenses.

## Test plan
- [x] `pytest tests/` — 413 passed, 0 failed (run inside `supoclip-backend` container against `postgres:5432`)
- [x] `pytest --cov=src` — 49% line coverage (up from 38%)
- [x] Existing `video_utils` / `youtube_utils` / `task_service` tests still pass via the re-export shims

🤖 Generated with [Claude Code](https://claude.com/claude-code)