### PR TITLE
fix(frontend): secure direct video uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,7 @@ BACKEND_AUTH_SECRET=change_me_backend_auth_secret
 APP_SETTINGS_ENCRYPTION_KEY=change_me_settings_encryption_secret
 ALLOW_UNSIGNED_BACKEND_AUTH=false
 AUTH_SIGNATURE_TTL_SECONDS=300
+# Include the frontend origin because browser video uploads go directly to the backend.
 CORS_ORIGINS=http://localhost:3107,http://sp.localhost:3107,http://supoclip.localhost:3107
 
 # Hosted mode does not allow free processing. This is reserved for future use.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ The backend can infer a default LLM from whichever API key is present, but setti
 | `DISABLE_SIGN_UP` | `false` | Prevents creation of new user accounts when set |
 | `NEXT_PUBLIC_LANDING_ONLY_MODE` | `false` | Restricts the UI to the landing page only |
 | `TEMP_DIR` | `/app/uploads` in Docker | Temporary backend working directory for uploads and processing |
-| `CORS_ORIGINS` | `http://localhost:3000,http://sp.localhost:3000` | Allowed browser origins for backend requests |
+| `CORS_ORIGINS` | `http://localhost:3000,http://sp.localhost:3000` | Allowed browser origins for backend requests, including direct browser video uploads |
 
 ## Analytics Settings
 

--- a/frontend/src/app/api/upload/authorization/route.test.ts
+++ b/frontend/src/app/api/upload/authorization/route.test.ts
@@ -1,0 +1,70 @@
+import { headers } from "next/headers";
+
+import { POST } from "./route";
+import { auth } from "@/lib/auth";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+describe("/api/upload/authorization", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+    vi.mocked(headers).mockResolvedValue(new Headers());
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(null as never);
+
+    const response = await POST();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("falls back to the server-side proxy when signed backend auth is unavailable", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      directUpload: false,
+      reason: "signed_backend_auth_required",
+    });
+  });
+
+  it("returns signed direct-upload headers when backend auth is configured", async () => {
+    vi.stubEnv("BACKEND_AUTH_SECRET", "secret");
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://api.supoclip.com/");
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+
+    const response = await POST();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      directUpload: true,
+      uploadUrl: "https://api.supoclip.com/upload",
+      headers: {
+        "x-supoclip-user-id": "user-1",
+        "x-supoclip-ts": "1700000000",
+        "x-supoclip-signature":
+          "cceb65b01012f5596122712d023d1def6663579f457362796a52133b3875c545",
+      },
+    });
+  });
+});

--- a/frontend/src/app/api/upload/authorization/route.ts
+++ b/frontend/src/app/api/upload/authorization/route.ts
@@ -1,0 +1,42 @@
+import { headers } from "next/headers";
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { buildBackendAuthHeaders, hasSignedBackendAuth } from "@/lib/backend-auth";
+
+export async function POST() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!hasSignedBackendAuth()) {
+    return NextResponse.json(
+      {
+        directUpload: false,
+        reason: "signed_backend_auth_required",
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
+  }
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+
+  return NextResponse.json(
+    {
+      directUpload: true,
+      uploadUrl: `${normalizedApiUrl}/upload`,
+      headers: buildBackendAuthHeaders(session.user.id),
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -52,6 +52,21 @@ interface FontOption {
 
 type OutputFormat = "vertical" | "vertical_pan" | "vertical_split" | "original";
 
+const MAX_VIDEO_UPLOAD_BYTES = 1_000_000_000;
+
+type DirectUploadAuthorization = {
+  directUpload: true;
+  uploadUrl: string;
+  headers: Record<string, string>;
+};
+
+type ProxyUploadAuthorization = {
+  directUpload: false;
+  reason: "signed_backend_auth_required";
+};
+
+type UploadAuthorization = DirectUploadAuthorization | ProxyUploadAuthorization;
+
 const extractYouTubeVideoId = (value: string): string | null => {
   const input = value.trim();
   if (!input) return null;
@@ -88,6 +103,85 @@ const getYouTubeThumbnailUrl = (value: string): string | null => {
   const videoId = extractYouTubeVideoId(value);
   return videoId ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg` : null;
 };
+
+async function requestUploadAuthorization(): Promise<UploadAuthorization> {
+  const response = await fetch("/api/upload/authorization", {
+    method: "POST",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const uploadError = await parseApiError(
+      response,
+      `Upload authorization error: ${response.status}`,
+    );
+    throw new Error(formatSupportMessage(uploadError));
+  }
+
+  return response.json() as Promise<UploadAuthorization>;
+}
+
+async function uploadVideoFile(file: File): Promise<string> {
+  if (file.size > MAX_VIDEO_UPLOAD_BYTES) {
+    throw new Error("Uploaded file is too large. Please upload a video under 1 GB.");
+  }
+
+  const uploadAuthorization = await requestUploadAuthorization();
+  if (!uploadAuthorization.directUpload) {
+    return uploadVideoFileViaProxy(file);
+  }
+
+  const formData = new FormData();
+  formData.append("video", file);
+
+  const uploadResponse = await fetch(uploadAuthorization.uploadUrl, {
+    method: "POST",
+    headers: uploadAuthorization.headers,
+    body: formData,
+  });
+
+  if (!uploadResponse.ok) {
+    const fallbackMessage =
+      uploadResponse.status === 413
+        ? "Uploaded file is too large. Please upload a video under 1 GB."
+        : `Upload error: ${uploadResponse.status}`;
+    const uploadError = await parseApiError(uploadResponse, fallbackMessage);
+    throw new Error(formatSupportMessage(uploadError));
+  }
+
+  const uploadResult = await uploadResponse.json();
+  if (typeof uploadResult.video_path !== "string" || !uploadResult.video_path) {
+    throw new Error("Upload finished without a video path. Please try again.");
+  }
+
+  return uploadResult.video_path;
+}
+
+async function uploadVideoFileViaProxy(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append("video", file);
+
+  const uploadResponse = await fetch("/api/upload", {
+    method: "POST",
+    body: formData,
+  });
+
+  if (!uploadResponse.ok) {
+    const fallbackMessage =
+      uploadResponse.status === 413
+        ? "Uploaded file is too large. Please upload a video under 1 GB."
+        : `Upload error: ${uploadResponse.status}`;
+    const uploadError = await parseApiError(uploadResponse, fallbackMessage);
+    throw new Error(formatSupportMessage(uploadError));
+  }
+
+  const uploadResult = await uploadResponse.json();
+  if (typeof uploadResult.video_path !== "string" || !uploadResult.video_path) {
+    throw new Error("Upload finished without a video path. Please try again.");
+  }
+
+  return uploadResult.video_path;
+}
 
 export default function Home() {
   const [url, setUrl] = useState("");
@@ -429,24 +523,7 @@ export default function Home() {
       if (sourceType === "upload" && fileRef.current) {
         setStatusMessage("Uploading video file...");
         setProgress(5);
-
-        const formData = new FormData();
-        formData.append("video", fileRef.current);
-        const uploadResponse = await fetch("/api/upload", {
-          method: "POST",
-          body: formData
-        });
-
-        if (!uploadResponse.ok) {
-          const uploadError = await parseApiError(
-            uploadResponse,
-            `Upload error: ${uploadResponse.status}`
-          );
-          throw new Error(formatSupportMessage(uploadError));
-        }
-
-        const uploadResult = await uploadResponse.json();
-        videoUrl = uploadResult.video_path;
+        videoUrl = await uploadVideoFile(fileRef.current);
       }
 
       // Step 1: Start the task (using new refactored endpoint)

--- a/frontend/src/lib/backend-auth.test.ts
+++ b/frontend/src/lib/backend-auth.test.ts
@@ -1,4 +1,8 @@
-import { buildBackendAuthHeaders } from "./backend-auth";
+import {
+  buildBackendAuthHeaders,
+  getBackendAuthSecret,
+  hasSignedBackendAuth,
+} from "./backend-auth";
 
 describe("buildBackendAuthHeaders", () => {
   const originalSecret = process.env.BACKEND_AUTH_SECRET;
@@ -18,12 +22,26 @@ describe("buildBackendAuthHeaders", () => {
     expect(buildBackendAuthHeaders("user-1")).toEqual({
       "x-supoclip-user-id": "user-1",
     });
+    expect(getBackendAuthSecret()).toBeNull();
+    expect(hasSignedBackendAuth()).toBe(false);
+  });
+
+  it("treats blank secrets as unavailable", () => {
+    process.env.BACKEND_AUTH_SECRET = "   ";
+
+    expect(buildBackendAuthHeaders("user-1")).toEqual({
+      "x-supoclip-user-id": "user-1",
+    });
+    expect(getBackendAuthSecret()).toBeNull();
+    expect(hasSignedBackendAuth()).toBe(false);
   });
 
   it("builds signed headers when a secret is configured", () => {
     process.env.BACKEND_AUTH_SECRET = "secret";
     vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
 
+    expect(getBackendAuthSecret()).toBe("secret");
+    expect(hasSignedBackendAuth()).toBe(true);
     expect(buildBackendAuthHeaders("user-1")).toEqual({
       "x-supoclip-user-id": "user-1",
       "x-supoclip-ts": "1700000000",

--- a/frontend/src/lib/backend-auth.ts
+++ b/frontend/src/lib/backend-auth.ts
@@ -1,7 +1,16 @@
 import crypto from "crypto";
 
+export function getBackendAuthSecret(): string | null {
+  const secret = process.env.BACKEND_AUTH_SECRET?.trim();
+  return secret || null;
+}
+
+export function hasSignedBackendAuth(): boolean {
+  return getBackendAuthSecret() !== null;
+}
+
 export function buildBackendAuthHeaders(userId: string): Record<string, string> {
-  const secret = process.env.BACKEND_AUTH_SECRET;
+  const secret = getBackendAuthSecret();
   if (!secret) {
     return { "x-supoclip-user-id": userId };
   }


### PR DESCRIPTION
## Summary
- route large video uploads through signed direct-backend requests when backend auth is configured
- fall back to the existing server-side upload proxy when signed backend auth is unavailable, so unsigned user-id headers are never exposed to the browser
- normalize blank backend auth secrets and document CORS requirements for direct browser uploads

## Validation
- pnpm run test src/lib/backend-auth.test.ts src/app/api/upload/authorization/route.test.ts
- pnpm run lint
- pnpm run build

## Notes
- This addresses the review finding that direct upload authorization could expose unsigned backend auth headers in unsigned/self-host deployments. Production remains on signed backend auth and uses the direct upload path.