### PR TITLE
Fix Postgres connection-pool exhaustion in clip file/export routes

### DIFF
--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -528,6 +528,13 @@ async def get_clip_file(
         if not clip_path.exists():
             raise HTTPException(status_code=404, detail="Clip file not found")
 
+        # Release the DB connection before streaming: FastAPI keeps a `Depends(get_db)`
+        # session open for the full response lifetime, and FileResponse can take many
+        # seconds (large file, slow client, range-request scrubbing). Without this, the
+        # read-only transaction above sits as "idle in transaction" in Postgres for the
+        # whole transfer, which exhausts the connection pool under concurrent playback.
+        await db.close()
+
         return FileResponse(
             path=str(clip_path),
             media_type="video/mp4",
@@ -776,6 +783,11 @@ async def export_clip(
             raise HTTPException(status_code=404, detail="Clip not found")
 
         from pathlib import Path
+
+        # Release the DB connection before the (potentially multi-minute) ffmpeg
+        # re-encode and file streaming below — see get_clip_file for why holding it
+        # here turns into "idle in transaction" connection-pool exhaustion.
+        await db.close()
 
         runtime_config = get_config()
         output_path = export_with_preset(

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -38,6 +38,16 @@ def _build_engine(database_url: str) -> AsyncEngine:
         max_overflow=20,
         pool_pre_ping=True,
         pool_recycle=3600,
+        # Safety net, not the primary fix (see get_clip_file/export_clip in
+        # api/routes/tasks.py for the actual leak this guards against): any
+        # session that ends up parked mid-transaction for this long is leaked,
+        # not legitimately busy — normal request/worker sessions commit on
+        # every DB write and never sit "idle in transaction" anywhere near
+        # this long. Killing it here returns the connection to the pool
+        # instead of letting it accumulate toward QueuePool exhaustion.
+        connect_args={
+            "server_settings": {"idle_in_transaction_session_timeout": "300000"}
+        },
     )
 
 


### PR DESCRIPTION
## Problem

Self-hosted instances exhaust their Postgres connection pool during normal use:

```
QueuePool limit of size 10 overflow 20 reached, connection timed out, timeout 30.00
```

`pg_stat_activity` shows the pool full of connections sitting in `idle in transaction`
— exactly `pool_size (10) + max_overflow (20)` of them in my repro. Every one of
those stuck connections was running the *same* query:

```sql
SELECT id, task_id, filename, file_path, ... FROM generated_clips WHERE id = $1
```

which only appears in `ClipRepository.get_clip_by_id`.

## Root cause

`get_clip_file` (`GET /tasks/{id}/clips/{id}/file`, used by the `<video>` player)
and `export_clip` (`GET /tasks/{id}/clips/{id}/export`) both:

1. Look up the clip through the request-scoped `Depends(get_db)` session — an
   implicit read-only transaction that's never committed or rolled back, then
2. Return a `FileResponse` — and for `export_clip`, only *after* an ffmpeg
   re-encode that can take minutes.

FastAPI keeps a `yield`-based dependency's session open for the **entire response
lifetime**. For a streamed video file (or a multi-minute export), the leftover read
transaction from step 1 sits as `idle in transaction` in Postgres for as long as the
transfer takes. Browsers fire many concurrent range requests when scrubbing/seeking
video, so just using the clip player normally can rack up several of these at once —
no heavy load required, just normal playback.

## Fix

Add `await db.close()` immediately after the clip lookup completes and *before* the
long-running operation begins, in both routes. `AsyncSession.close()` rolls back any
open transaction and returns the connection to the pool right away;
`get_db`'s `finally: await session.close()` is then a safe no-op.

Also added `idle_in_transaction_session_timeout = 5min` to the engine's
`connect_args.server_settings` as a safety net against *future* leaks of the same
shape — five minutes is far longer than any legitimate transaction in this codebase
(every write path commits immediately, and the worker commits on every progress
update), so it only reaps connections that are genuinely stuck, not busy ones.

## Verification

Reproduced the exact failure mode with a small concurrency test (25 simulated
concurrent "serve a clip file" requests, 4-second simulated stream each):

| | peak `idle in transaction` | time with ≥50% of requests stuck |
|---|---|---|
| Before fix (no `db.close()`) | 25/25 | **3.6s — 100% of samples (71/71)** |
| After fix (with `db.close()`) | 15/25 (one transient sample) | **0.05s — then 0 for the rest of the run** |

The "before" column reproduces the sustained pile-up that exhausts the pool in
production; the "after" column shows a single harmless transitional blip (the
round-trip for `close()`'s rollback) before connections return to the pool
immediately and stay there.

## Scope note

I also looked at whether the worker (`workers/tasks.py`) holding one DB session open
across the whole multi-minute pipeline contributes to this — it doesn't in practice,
since `update_task_status` commits on every progress update, so that session is never
idle-in-transaction for long. The leak is fully attributable to the two routes above.