### PR TITLE
feat(frontend): default caption font to the bold impact font

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -198,7 +198,7 @@ export default function Home() {
   const isAdmin = Boolean((session?.user as { is_admin?: boolean } | undefined)?.is_admin);
 
   // Font customization states
-  const [fontFamily, setFontFamily] = useState("TikTokSans-Regular");
+  const [fontFamily, setFontFamily] = useState("THEBOLDFONT");
   const [fontSize, setFontSize] = useState(24);
   const [fontColor, setFontColor] = useState("#FFFFFF");
   const [availableFonts, setAvailableFonts] = useState<FontOption[]>([]);


### PR DESCRIPTION
Defaults the caption font (`fontFamily` state in the create flow) to `THEBOLDFONT` so new tasks use the punchy bold caption look by default, matching the upgraded default caption template in the backend pipeline PR (#51).

One-line change; independent of #51 (renders fine either way).