### PR TITLE
feat(mcp): SupoClip MCP server

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
         run: cd frontend && npm install
       - name: Run frontend unit tests
@@ -114,8 +112,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
       - name: Install backend dependencies
         run: cd backend && uv sync --all-groups
       - name: Install frontend dependencies

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,3 +201,18 @@ Edit `backend/src/ai.py`: `simplified_system_prompt` controls selection criteria
 - Output: 9:16 vertical format, H.264, even pixel dimensions (`round_to_even()`)
 - Subtitles positioned at 75% down the frame
 - Virality scoring: `hook_score`, `engagement_score`, `value_score`, `shareability_score` (0-25 each, summed to `virality_score` 0-100)
+
+## MCP Server
+
+`mcp/` is a standalone [MCP](https://modelcontextprotocol.io) server
+(`supoclip-mcp`, Python/FastMCP, stdio) that exposes SupoClip to MCP clients
+(Claude Desktop/Code, Cursor, …). It is a thin client over the REST API.
+
+- **Default target:** the hosted API `https://api.supoclip.com`. Override with
+  `SUPOCLIP_API_URL` for self-hosting (e.g. `http://localhost:8000`).
+- **Auth:** a per-user API key in `SUPOCLIP_API_KEY` (see API keys above).
+  Self-hosters may instead use `SUPOCLIP_USER_ID` (+ `SUPOCLIP_AUTH_SECRET` when
+  signing is enforced).
+- **Tools:** create/list/get/wait/cancel/resume/delete tasks, list/download/
+  export clips, and public discovery (templates, transitions, fonts, B-roll).
+- Run with `cd mcp && uv run supoclip-mcp`. Details in `mcp/README.md`.

--- a/backend/src/video_utils.py
+++ b/backend/src/video_utils.py
@@ -119,7 +119,14 @@ def _prepare_audio_for_transcription(video_path: Path) -> Path:
         "64k",
         str(audio_path),
     ]
-    result = run_ffmpeg_command(command, timeout=900)
+    try:
+        result = run_ffmpeg_command(command, timeout=900)
+    except FileNotFoundError:
+        logger.warning(
+            "ffmpeg is not available; falling back to source video for transcription"
+        )
+        return video_path
+
     if result.returncode != 0 or not audio_path.exists() or audio_path.stat().st_size == 0:
         logger.warning(
             "Failed to extract transcription audio with ffmpeg; falling back to source video"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -14,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.config import Config
+from src.config import Config, set_config_override
 from src.database import configure_database, init_db, reset_database_state
 from src.main_refactored import create_app
 
@@ -90,7 +90,10 @@ async def app(db_session):
     config.redis_port = int(os.getenv("REDIS_PORT", "6379"))
 
     test_app = create_app(config=config, queue_adapter=FakeQueueAdapter)
-    return test_app
+    try:
+        yield test_app
+    finally:
+        set_config_override(None)
 
 
 @pytest.fixture()

--- a/frontend/src/app/api/upload/authorization/route.test.ts
+++ b/frontend/src/app/api/upload/authorization/route.test.ts
@@ -32,6 +32,7 @@ describe("/api/upload/authorization", () => {
   });
 
   it("falls back to the server-side proxy when signed backend auth is unavailable", async () => {
+    vi.stubEnv("BACKEND_AUTH_SECRET", "");
     vi.mocked(auth.api.getSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -1,0 +1,27 @@
+# SupoClip MCP server configuration
+#
+# Copy to .env (or set these in your MCP client config) and fill in values.
+
+# --- Authentication (required for everything except the public discovery tools) ---
+# Create a key in your SupoClip account: Settings -> API Keys. Starts with "sk_".
+SUPOCLIP_API_KEY=sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# --- Backend selection ---
+# Defaults to the official hosted instance. Override for self-hosting.
+# SUPOCLIP_API_URL=https://api.supoclip.com
+# SUPOCLIP_API_URL=http://localhost:8000
+
+# --- Where downloaded/exported clips are written ---
+# Defaults to ./supoclip-downloads (relative to the server's working directory).
+# SUPOCLIP_DOWNLOAD_DIR=/absolute/path/to/clips
+
+# --- HTTP timeout for non-download requests, in seconds (default 60) ---
+# SUPOCLIP_TIMEOUT=60
+
+# --- Self-hosting auth alternatives (only if you are NOT using an API key) ---
+# For a self-hosted backend you can authenticate with a user id directly:
+#   * If the backend enforces signing (BACKEND_AUTH_SECRET set), provide both:
+# SUPOCLIP_USER_ID=your-user-id
+# SUPOCLIP_AUTH_SECRET=the-backend-BACKEND_AUTH_SECRET
+#   * If the backend runs with ALLOW_UNSIGNED_BACKEND_AUTH=true, the user id alone is enough:
+# SUPOCLIP_USER_ID=your-user-id

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,10 @@
+.venv/
+__pycache__/
+*.pyc
+.env
+supoclip-downloads/
+dist/
+build/
+*.egg-info/
+.uv/
+uv.lock

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,116 @@
+# SupoClip MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server for
+[SupoClip](https://supoclip.com) — turn long-form videos (YouTube links or
+direct URLs) into short, vertical, subtitled viral clips from any MCP client
+(Claude Desktop, Claude Code, Cursor, etc.).
+
+By default it talks to the **official hosted SupoClip API** at
+`https://api.supoclip.com`. Point it at your own deployment by setting
+`SUPOCLIP_API_URL`.
+
+## What it can do
+
+| Tool | Auth | Description |
+|------|:----:|-------------|
+| `supoclip_health` | – | API status + how this server is configured |
+| `supoclip_list_caption_templates` | – | Available caption styles (default, hormozi, mrbeast, …) |
+| `supoclip_list_transitions` | – | Available transition effects |
+| `supoclip_broll_status` | – | Whether B-roll overlays are configured |
+| `supoclip_list_fonts` | ✓ | Subtitle fonts available to your account |
+| `supoclip_billing_summary` | ✓ | Plan, usage and remaining quota |
+| `supoclip_create_clip_task` | ✓ | Start clipping a video → returns a `task_id` |
+| `supoclip_list_tasks` | ✓ | List your tasks |
+| `supoclip_get_task` | ✓ | Task status, progress and clips |
+| `supoclip_wait_for_task` | ✓ | Poll until a task finishes |
+| `supoclip_list_clips` | ✓ | List a task's generated clips |
+| `supoclip_download_clip` | ✓ | Save a clip's MP4 to disk |
+| `supoclip_export_clip` | ✓ | Re-encode + save with a platform preset (tiktok/reels/shorts) |
+| `supoclip_cancel_task` / `supoclip_resume_task` / `supoclip_delete_task` | ✓ | Manage tasks |
+
+Tools marked ✓ require an API key (or self-host credentials, see below).
+
+## Getting an API key
+
+1. Sign in at [supoclip.com](https://supoclip.com).
+2. Go to **Settings → API Keys**.
+3. Create a key and copy it (it's shown only once). It looks like `sk_…`.
+
+## Configuration
+
+All configuration is via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SUPOCLIP_API_KEY` | – | Your API key (recommended auth). |
+| `SUPOCLIP_API_URL` | `https://api.supoclip.com` | Backend base URL. Set for self-hosting. |
+| `SUPOCLIP_DOWNLOAD_DIR` | `./supoclip-downloads` | Where downloaded/exported clips are written. |
+| `SUPOCLIP_TIMEOUT` | `60` | HTTP timeout (seconds) for non-download requests. |
+| `SUPOCLIP_USER_ID` | – | Self-host only: authenticate by user id (see below). |
+| `SUPOCLIP_AUTH_SECRET` | – | Self-host only: backend `BACKEND_AUTH_SECRET` for HMAC signing. |
+
+### Self-hosting auth
+
+If you run your own backend you have three options:
+
+- **API key** (same as hosted): create a key and set `SUPOCLIP_API_KEY`.
+- **Signed headers**: set `SUPOCLIP_USER_ID` + `SUPOCLIP_AUTH_SECRET` (your
+  backend's `BACKEND_AUTH_SECRET`).
+- **Unsigned**: if the backend runs with `ALLOW_UNSIGNED_BACKEND_AUTH=true`,
+  just set `SUPOCLIP_USER_ID`.
+
+Auth precedence is: API key → signed headers → unsigned user id.
+
+## Install & run
+
+Requires Python 3.10+. With [uv](https://docs.astral.sh/uv/):
+
+```bash
+cd mcp
+uv run supoclip-mcp        # runs the stdio server
+```
+
+Or install into the current environment:
+
+```bash
+pip install -e .
+supoclip-mcp
+```
+
+## Use with Claude Desktop / Claude Code
+
+Add to your MCP client config (e.g. `claude_desktop_config.json`, or via
+`claude mcp add`). Example using `uv` to run from a checkout:
+
+```json
+{
+  "mcpServers": {
+    "supoclip": {
+      "command": "uv",
+      "args": ["--directory", "/absolute/path/to/supoclip/mcp", "run", "supoclip-mcp"],
+      "env": {
+        "SUPOCLIP_API_KEY": "sk_your_key_here"
+      }
+    }
+  }
+}
+```
+
+For a self-hosted backend, add `"SUPOCLIP_API_URL": "http://localhost:8000"` to `env`.
+
+With Claude Code:
+
+```bash
+claude mcp add supoclip -e SUPOCLIP_API_KEY=sk_your_key_here \
+  -- uv --directory /absolute/path/to/supoclip/mcp run supoclip-mcp
+```
+
+## Example prompts
+
+- "Use supoclip to make clips from https://youtu.be/… with the hormozi caption template, then wait for it and download the top clip."
+- "List my recent supoclip tasks and show the virality scores of the latest one's clips."
+- "Export clip <id> from task <id> as a TikTok preset."
+
+## License
+
+AGPL-3.0-or-later, matching the SupoClip project.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "supoclip-mcp"
+version = "0.1.0"
+description = "Model Context Protocol server for SupoClip — turn long videos into viral short clips."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "AGPL-3.0-or-later" }
+authors = [{ name = "SupoClip" }]
+keywords = ["mcp", "supoclip", "video", "clips", "ai"]
+dependencies = [
+    "mcp[cli]>=1.4.0",
+    "httpx>=0.27.0",
+    "pydantic>=2.6.0",
+]
+
+[project.scripts]
+supoclip-mcp = "supoclip_mcp.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/supoclip_mcp"]

--- a/mcp/src/supoclip_mcp/__init__.py
+++ b/mcp/src/supoclip_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""SupoClip MCP server package."""
+
+__version__ = "0.1.0"

--- a/mcp/src/supoclip_mcp/client.py
+++ b/mcp/src/supoclip_mcp/client.py
@@ -1,0 +1,189 @@
+"""
+Thin async HTTP client for the SupoClip backend API.
+
+Authentication is resolved from :class:`~supoclip_mcp.config.Settings` and
+supports three modes, tried in priority order:
+
+1. ``api_key``         -> ``Authorization: Bearer <key>`` (recommended; the
+   default for the hosted service).
+2. ``signed_headers``  -> the frontend's HMAC scheme, when a user id and the
+   backend auth secret are both provided (useful for self-hosting).
+3. ``unsigned_user_id`` -> a bare ``x-supoclip-user-id`` header, for a
+   self-hosted backend running with ``ALLOW_UNSIGNED_BACKEND_AUTH=true``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .config import Settings
+
+
+class SupoClipError(Exception):
+    """A friendly, already-formatted error suitable for returning to the model."""
+
+
+class AuthNotConfiguredError(SupoClipError):
+    """Raised when an authenticated operation is attempted without credentials."""
+
+
+def _signed_headers(user_id: str, secret: str) -> Dict[str, str]:
+    timestamp = str(int(time.time()))
+    payload = f"{user_id}:{timestamp}".encode("utf-8")
+    signature = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+    return {
+        "x-supoclip-user-id": user_id,
+        "x-supoclip-ts": timestamp,
+        "x-supoclip-signature": signature,
+    }
+
+
+class SupoClipClient:
+    """Async client wrapping the SupoClip REST API."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    # -- auth ---------------------------------------------------------------
+    def _auth_headers(self) -> Dict[str, str]:
+        mode = self.settings.auth_mode
+        if mode == "api_key":
+            return {"Authorization": f"Bearer {self.settings.api_key}"}
+        if mode == "signed_headers":
+            return _signed_headers(self.settings.user_id, self.settings.auth_secret)  # type: ignore[arg-type]
+        if mode == "unsigned_user_id":
+            return {"x-supoclip-user-id": self.settings.user_id}  # type: ignore[dict-item]
+        return {}
+
+    def _require_auth(self) -> None:
+        if not self.settings.is_authenticated:
+            raise AuthNotConfiguredError(
+                "No credentials configured. Set SUPOCLIP_API_KEY to a key created "
+                "in your SupoClip account (Settings -> API Keys). For a self-hosted "
+                "backend you may instead set SUPOCLIP_USER_ID (+ SUPOCLIP_AUTH_SECRET "
+                "if signing is enforced)."
+            )
+
+    # -- requests -----------------------------------------------------------
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        authenticated: bool = True,
+    ) -> Any:
+        """Make a JSON request and return the decoded body."""
+        if authenticated:
+            self._require_auth()
+
+        headers = {"Accept": "application/json"}
+        if authenticated:
+            headers.update(self._auth_headers())
+
+        url = f"{self.settings.api_url}{path}"
+        try:
+            async with httpx.AsyncClient(timeout=self.settings.timeout) as client:
+                response = await client.request(
+                    method, url, params=params, json=json_body, headers=headers
+                )
+        except httpx.TimeoutException as exc:
+            raise SupoClipError(
+                f"Request to {path} timed out after {self.settings.timeout:g}s."
+            ) from exc
+        except httpx.HTTPError as exc:
+            raise SupoClipError(f"Could not reach SupoClip at {url}: {exc}") from exc
+
+        return self._parse(response, path)
+
+    async def download(
+        self,
+        path: str,
+        destination_dir: str,
+        filename: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Stream a binary file (a clip) to ``destination_dir`` and return its path."""
+        self._require_auth()
+        headers = self._auth_headers()
+        url = f"{self.settings.api_url}{path}"
+
+        dest_dir = Path(destination_dir).expanduser()
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest_path = dest_dir / filename
+
+        bytes_written = 0
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                async with client.stream(
+                    "GET", url, params=params, headers=headers
+                ) as response:
+                    if response.status_code >= 400:
+                        body = (await response.aread()).decode("utf-8", "replace")
+                        raise SupoClipError(
+                            _error_message(response.status_code, body, path)
+                        )
+                    with dest_path.open("wb") as handle:
+                        async for chunk in response.aiter_bytes(chunk_size=1 << 16):
+                            handle.write(chunk)
+                            bytes_written += len(chunk)
+        except httpx.HTTPError as exc:
+            raise SupoClipError(f"Download from {url} failed: {exc}") from exc
+
+        return {
+            "path": str(dest_path.resolve()),
+            "filename": filename,
+            "bytes": bytes_written,
+        }
+
+    # -- helpers ------------------------------------------------------------
+    @staticmethod
+    def _parse(response: httpx.Response, path: str) -> Any:
+        if response.status_code >= 400:
+            raise SupoClipError(
+                _error_message(response.status_code, response.text, path)
+            )
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError:
+            return {"raw": response.text}
+
+
+def _error_message(status: int, body: str, path: str) -> str:
+    """Turn a backend error response into an actionable message."""
+    detail: Any = body
+    try:
+        import json
+
+        parsed = json.loads(body)
+        detail = parsed.get("detail", parsed) if isinstance(parsed, dict) else parsed
+    except ValueError:
+        pass
+
+    if status == 401:
+        return (
+            "Authentication failed (401). Check SUPOCLIP_API_KEY is valid and not "
+            f"revoked. Backend said: {detail}"
+        )
+    if status == 402:
+        return (
+            "Payment required (402): this account needs an active paid plan to "
+            f"process videos. Backend said: {detail}"
+        )
+    if status == 403:
+        return f"Permission denied (403): you do not have access to this resource. {detail}"
+    if status == 404:
+        return f"Not found (404) for {path}: {detail}"
+    if status == 429:
+        return "Rate limited (429). Wait a moment and try again."
+    return f"SupoClip API error ({status}) for {path}: {detail}"

--- a/mcp/src/supoclip_mcp/config.py
+++ b/mcp/src/supoclip_mcp/config.py
@@ -1,0 +1,73 @@
+"""
+Configuration for the SupoClip MCP server.
+
+All settings come from environment variables so the same server binary works
+against the official hosted instance (the default) or any self-hosted backend.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+# The official hosted SupoClip API. Override with SUPOCLIP_API_URL to point at
+# a self-hosted backend (e.g. http://localhost:8000).
+DEFAULT_API_URL = "https://api.supoclip.com"
+
+
+def _clean(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Resolved runtime configuration."""
+
+    api_url: str
+    api_key: Optional[str]
+    user_id: Optional[str]
+    auth_secret: Optional[str]
+    download_dir: str
+    timeout: float
+
+    @property
+    def auth_mode(self) -> str:
+        """Describe how requests will be authenticated."""
+        if self.api_key:
+            return "api_key"
+        if self.user_id and self.auth_secret:
+            return "signed_headers"
+        if self.user_id:
+            return "unsigned_user_id"
+        return "none"
+
+    @property
+    def is_authenticated(self) -> bool:
+        return self.auth_mode != "none"
+
+
+def load_settings() -> Settings:
+    """Build :class:`Settings` from the current environment."""
+    api_url = (_clean(os.getenv("SUPOCLIP_API_URL")) or DEFAULT_API_URL).rstrip("/")
+    download_dir = _clean(os.getenv("SUPOCLIP_DOWNLOAD_DIR")) or os.path.join(
+        os.getcwd(), "supoclip-downloads"
+    )
+
+    raw_timeout = _clean(os.getenv("SUPOCLIP_TIMEOUT"))
+    try:
+        timeout = float(raw_timeout) if raw_timeout else 60.0
+    except ValueError:
+        timeout = 60.0
+
+    return Settings(
+        api_url=api_url,
+        api_key=_clean(os.getenv("SUPOCLIP_API_KEY")),
+        user_id=_clean(os.getenv("SUPOCLIP_USER_ID")),
+        auth_secret=_clean(os.getenv("SUPOCLIP_AUTH_SECRET")),
+        download_dir=download_dir,
+        timeout=timeout,
+    )

--- a/mcp/src/supoclip_mcp/server.py
+++ b/mcp/src/supoclip_mcp/server.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""
+MCP server for SupoClip — an AI tool that turns long-form videos into short,
+vertical, subtitled viral clips.
+
+The server talks to the SupoClip REST API. By default it targets the official
+hosted instance at ``https://api.supoclip.com``; set ``SUPOCLIP_API_URL`` to
+use a self-hosted backend. Authenticate by creating an API key in your SupoClip
+account and exposing it as ``SUPOCLIP_API_KEY``.
+
+Typical workflow:
+    1. ``supoclip_create_clip_task`` with a YouTube URL  -> returns a task_id
+    2. ``supoclip_wait_for_task`` (or poll ``supoclip_get_task``) until done
+    3. ``supoclip_list_clips`` / ``supoclip_download_clip`` to retrieve results
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import json
+import os
+import re
+import time
+from typing import Annotated, Awaitable, Callable, Optional
+
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import Field
+
+try:  # Python 3.10 lacks typing.Literal niceties only in edge cases; import is fine.
+    from typing import Literal
+except ImportError:  # pragma: no cover
+    from typing_extensions import Literal  # type: ignore
+
+from .client import AuthNotConfiguredError, SupoClipClient, SupoClipError
+from .config import load_settings
+
+SETTINGS = load_settings()
+CLIENT = SupoClipClient(SETTINGS)
+
+mcp = FastMCP("supoclip_mcp")
+
+ProcessingMode = Literal["fast", "balanced", "quality"]
+OutputFormat = Literal["vertical", "vertical_pan", "vertical_split", "original"]
+ExportPreset = Literal["tiktok", "reels", "shorts"]
+TERMINAL_STATES = {"completed", "error", "cancelled"}
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _json(data: object) -> str:
+    return json.dumps(data, indent=2, default=str, ensure_ascii=False)
+
+
+def tool_errors(func: Callable[..., Awaitable[str]]) -> Callable[..., Awaitable[str]]:
+    """Wrap a tool so backend/auth errors come back as readable text, not stack traces."""
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs) -> str:
+        try:
+            return await func(*args, **kwargs)
+        except AuthNotConfiguredError as exc:
+            return f"Error: {exc}"
+        except SupoClipError as exc:
+            return f"Error: {exc}"
+        except Exception as exc:  # pragma: no cover - defensive
+            return f"Error: unexpected {type(exc).__name__}: {exc}"
+
+    return wrapper
+
+
+def _safe_filename(name: str, default: str) -> str:
+    """Reduce an arbitrary string to a safe ``.mp4`` basename (no path traversal)."""
+    base = os.path.basename((name or "").strip()) or default
+    base = re.sub(r"[^A-Za-z0-9._-]", "_", base)
+    if not base.lower().endswith(".mp4"):
+        base = f"{base}.mp4"
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# Public, unauthenticated tools
+# --------------------------------------------------------------------------- #
+@mcp.tool(
+    name="supoclip_health",
+    annotations={
+        "title": "SupoClip Health & Config",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_health() -> str:
+    """Report SupoClip API status and how this MCP server is configured.
+
+    Use this first to confirm connectivity and that credentials are set up. It
+    requires no authentication and reveals no secrets.
+
+    Returns:
+        str: JSON with the configured ``api_url``, ``auth_mode``
+        (one of ``api_key``/``signed_headers``/``unsigned_user_id``/``none``),
+        whether the server is ``authenticated``, the download directory, and the
+        backend's reported version/status.
+    """
+    root = await CLIENT.request("GET", "/", authenticated=False)
+    health = await CLIENT.request("GET", "/health", authenticated=False)
+    return _json(
+        {
+            "configured": {
+                "api_url": SETTINGS.api_url,
+                "auth_mode": SETTINGS.auth_mode,
+                "authenticated": SETTINGS.is_authenticated,
+                "download_dir": SETTINGS.download_dir,
+            },
+            "backend": root,
+            "health": health,
+        }
+    )
+
+
+@mcp.tool(
+    name="supoclip_list_caption_templates",
+    annotations={
+        "title": "List Caption Templates",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_list_caption_templates() -> str:
+    """List the caption/subtitle templates available for clip generation.
+
+    Each template id (e.g. ``default``, ``hormozi``, ``mrbeast``) can be passed
+    as ``caption_template`` to ``supoclip_create_clip_task``. No auth required.
+
+    Returns:
+        str: JSON ``{"templates": [{"id", "name", "description", "animation",
+        "font_family", "font_size", "font_color", ...}]}``.
+    """
+    data = await CLIENT.request("GET", "/caption-templates", authenticated=False)
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_list_transitions",
+    annotations={
+        "title": "List Transition Effects",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_list_transitions() -> str:
+    """List available video transition effects. No auth required.
+
+    Returns:
+        str: JSON ``{"transitions": [{"name", "display_name", "file_path"}]}``.
+    """
+    data = await CLIENT.request("GET", "/transitions", authenticated=False)
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_broll_status",
+    annotations={
+        "title": "B-roll Availability",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_broll_status() -> str:
+    """Report whether automatic B-roll overlays are configured on the backend.
+
+    If ``configured`` is false, passing ``include_broll=true`` when creating a
+    task has no effect. No auth required.
+
+    Returns:
+        str: JSON ``{"configured": bool, "provider": str | null}``.
+    """
+    data = await CLIENT.request("GET", "/broll/status", authenticated=False)
+    return _json(data)
+
+
+# --------------------------------------------------------------------------- #
+# Authenticated tools — discovery & account
+# --------------------------------------------------------------------------- #
+@mcp.tool(
+    name="supoclip_list_fonts",
+    annotations={
+        "title": "List Fonts",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_list_fonts() -> str:
+    """List subtitle fonts available to the authenticated account.
+
+    Any returned ``name`` can be used as ``font_family`` in
+    ``supoclip_create_clip_task``. Requires authentication.
+
+    Returns:
+        str: JSON ``{"fonts": [{"name", "display_name", ...}]}``.
+    """
+    data = await CLIENT.request("GET", "/fonts")
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_billing_summary",
+    annotations={
+        "title": "Billing & Usage Summary",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_billing_summary() -> str:
+    """Get the authenticated account's plan, usage and remaining quota.
+
+    Useful before creating tasks to check whether a paid plan / remaining quota
+    allows another video. Requires authentication.
+
+    Returns:
+        str: JSON with ``plan``, ``subscription_status``, ``usage_count``,
+        ``usage_limit``, ``remaining``, ``upgrade_required`` and
+        ``monetization_enabled``.
+    """
+    data = await CLIENT.request("GET", "/tasks/billing/summary")
+    return _json(data)
+
+
+# --------------------------------------------------------------------------- #
+# Authenticated tools — task lifecycle
+# --------------------------------------------------------------------------- #
+@mcp.tool(
+    name="supoclip_create_clip_task",
+    annotations={
+        "title": "Create Clipping Task",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_create_clip_task(
+    url: Annotated[
+        str,
+        Field(
+            description="Video source URL — a YouTube link or a direct/uploaded video URL.",
+            min_length=4,
+            max_length=2000,
+        ),
+    ],
+    title: Annotated[
+        Optional[str],
+        Field(default=None, description="Optional title for the task.", max_length=300),
+    ] = None,
+    processing_mode: Annotated[
+        ProcessingMode,
+        Field(
+            default="fast",
+            description="Speed/quality tradeoff: 'fast' (fewer clips, quickest), "
+            "'balanced', or 'quality' (best, slowest).",
+        ),
+    ] = "fast",
+    output_format: Annotated[
+        OutputFormat,
+        Field(
+            default="vertical",
+            description="Clip framing: 'vertical' (9:16 face-tracked), 'vertical_pan', "
+            "'vertical_split', or 'original' aspect ratio.",
+        ),
+    ] = "vertical",
+    add_subtitles: Annotated[
+        bool,
+        Field(default=True, description="Burn word-synced subtitles into the clips."),
+    ] = True,
+    caption_template: Annotated[
+        str,
+        Field(
+            default="default",
+            description="Caption template id (see supoclip_list_caption_templates), "
+            "e.g. 'default', 'hormozi', 'mrbeast'.",
+            max_length=50,
+        ),
+    ] = "default",
+    include_broll: Annotated[
+        bool,
+        Field(
+            default=False,
+            description="Overlay automatic B-roll (only effective if the backend has "
+            "B-roll configured — check supoclip_broll_status).",
+        ),
+    ] = False,
+    font_family: Annotated[
+        Optional[str],
+        Field(default=None, description="Subtitle font name (see supoclip_list_fonts).", max_length=100),
+    ] = None,
+    font_size: Annotated[
+        Optional[int],
+        Field(default=None, description="Subtitle font size (12-72).", ge=12, le=72),
+    ] = None,
+    font_color: Annotated[
+        Optional[str],
+        Field(
+            default=None,
+            description="Subtitle color as a hex string like '#FFFFFF'.",
+            pattern=r"^#[0-9A-Fa-f]{6}$",
+        ),
+    ] = None,
+    cut_long_pauses: Annotated[
+        Optional[bool],
+        Field(default=None, description="Remove long silent pauses from clips."),
+    ] = None,
+    remove_filler_words: Annotated[
+        Optional[bool],
+        Field(default=None, description="Remove filler words (um, uh, like, ...) from clips."),
+    ] = None,
+) -> str:
+    """Create a SupoClip task that downloads a video and generates viral short clips.
+
+    Processing is asynchronous: this returns immediately with a ``task_id``.
+    Track progress with ``supoclip_wait_for_task`` or ``supoclip_get_task``, then
+    fetch results with ``supoclip_list_clips`` / ``supoclip_download_clip``.
+
+    Requires authentication. On the hosted service a paid plan / available quota
+    may be required (a 402 error indicates this — see ``supoclip_billing_summary``).
+
+    Args:
+        url: YouTube or direct video URL to clip.
+        title: Optional task title.
+        processing_mode: 'fast' | 'balanced' | 'quality'.
+        output_format: 'vertical' | 'vertical_pan' | 'vertical_split' | 'original'.
+        add_subtitles: Whether to burn in subtitles.
+        caption_template: Caption template id.
+        include_broll: Whether to add B-roll overlays.
+        font_family / font_size / font_color: Optional subtitle styling overrides.
+        cut_long_pauses / remove_filler_words: Optional cleanup toggles.
+
+    Returns:
+        str: JSON ``{"task_id": str, "job_id": str, "message": str}`` on success.
+    """
+    source: dict = {"url": url}
+    if title:
+        source["title"] = title
+
+    body: dict = {
+        "source": source,
+        "processing_mode": processing_mode,
+        "output_format": output_format,
+        "add_subtitles": add_subtitles,
+        "caption_template": caption_template,
+        "include_broll": include_broll,
+    }
+
+    font_options: dict = {}
+    if font_family:
+        font_options["font_family"] = font_family
+    if font_size is not None:
+        font_options["font_size"] = font_size
+    if font_color:
+        font_options["font_color"] = font_color
+    if font_options:
+        body["font_options"] = font_options
+
+    if cut_long_pauses is not None:
+        body["cut_long_pauses"] = cut_long_pauses
+    if remove_filler_words is not None:
+        body["remove_filler_words"] = remove_filler_words
+
+    data = await CLIENT.request("POST", "/tasks/", json_body=body)
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_list_tasks",
+    annotations={
+        "title": "List Tasks",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_list_tasks(
+    limit: Annotated[
+        int,
+        Field(default=50, description="Maximum number of tasks to return.", ge=1, le=200),
+    ] = 50,
+) -> str:
+    """List the authenticated user's clipping tasks, newest first.
+
+    Requires authentication.
+
+    Args:
+        limit: Maximum tasks to return (1-200, default 50).
+
+    Returns:
+        str: JSON ``{"tasks": [{"id", "status", "progress", "title", ...}], "total": int}``.
+    """
+    data = await CLIENT.request("GET", "/tasks/", params={"limit": limit})
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_get_task",
+    annotations={
+        "title": "Get Task",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_get_task(
+    task_id: Annotated[str, Field(description="The task id returned by create_clip_task.", min_length=1)],
+) -> str:
+    """Get a task's status, progress and generated clips.
+
+    Requires authentication and ownership of the task.
+
+    Args:
+        task_id: The task id.
+
+    Returns:
+        str: JSON of the task including ``status`` (queued/processing/completed/
+        error/cancelled), ``progress`` (0-100), ``progress_message`` and a
+        ``clips`` array (each with ``id``, ``filename``, timing and scores).
+    """
+    data = await CLIENT.request("GET", f"/tasks/{task_id}")
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_wait_for_task",
+    annotations={
+        "title": "Wait For Task",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_wait_for_task(
+    task_id: Annotated[str, Field(description="The task id to wait on.", min_length=1)],
+    timeout_seconds: Annotated[
+        int,
+        Field(default=600, description="Give up after this many seconds.", ge=5, le=3600),
+    ] = 600,
+    poll_interval_seconds: Annotated[
+        int,
+        Field(default=5, description="Seconds between status checks.", ge=2, le=60),
+    ] = 5,
+    ctx: Optional[Context] = None,
+) -> str:
+    """Poll a task until it finishes (completed/error/cancelled) or times out.
+
+    Convenience wrapper around ``supoclip_get_task`` for the asynchronous
+    pipeline. Reports progress while waiting. Requires authentication.
+
+    Args:
+        task_id: The task id to wait on.
+        timeout_seconds: Max seconds to wait (5-3600, default 600).
+        poll_interval_seconds: Seconds between polls (2-60, default 5).
+
+    Returns:
+        str: JSON ``{"status", "progress", "timed_out": bool, "task": {...}}``.
+        When ``status`` is ``completed`` the ``task.clips`` array holds results.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    last: dict = {}
+    while True:
+        last = await CLIENT.request("GET", f"/tasks/{task_id}")
+        status = str(last.get("status", "unknown"))
+        progress = last.get("progress", 0)
+
+        if ctx is not None:
+            try:
+                await ctx.report_progress(
+                    progress=float(progress or 0) / 100.0,
+                    message=f"{status}: {last.get('progress_message', '')}",
+                )
+            except Exception:
+                pass
+
+        if status in TERMINAL_STATES:
+            return _json(
+                {"status": status, "progress": progress, "timed_out": False, "task": last}
+            )
+
+        if time.monotonic() >= deadline:
+            return _json(
+                {
+                    "status": status,
+                    "progress": progress,
+                    "timed_out": True,
+                    "message": f"Still '{status}' after {timeout_seconds}s; poll again later.",
+                    "task": last,
+                }
+            )
+
+        await asyncio.sleep(poll_interval_seconds)
+
+
+@mcp.tool(
+    name="supoclip_list_clips",
+    annotations={
+        "title": "List Clips",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_list_clips(
+    task_id: Annotated[str, Field(description="The task id whose clips to list.", min_length=1)],
+) -> str:
+    """List the generated clips for a task. Requires authentication.
+
+    Args:
+        task_id: The task id.
+
+    Returns:
+        str: JSON ``{"task_id", "clips": [{"id", "filename", "start_time",
+        "end_time", "virality_score", ...}], "total_clips": int}``.
+    """
+    data = await CLIENT.request("GET", f"/tasks/{task_id}/clips")
+    return _json(data)
+
+
+# --------------------------------------------------------------------------- #
+# Authenticated tools — retrieval (download to disk)
+# --------------------------------------------------------------------------- #
+@mcp.tool(
+    name="supoclip_download_clip",
+    annotations={
+        "title": "Download Clip",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_download_clip(
+    task_id: Annotated[str, Field(description="The task id that owns the clip.", min_length=1)],
+    clip_id: Annotated[str, Field(description="The clip id (from supoclip_list_clips).", min_length=1)],
+    filename: Annotated[
+        Optional[str],
+        Field(default=None, description="Optional output filename; '.mp4' is enforced.", max_length=200),
+    ] = None,
+) -> str:
+    """Download a generated clip's MP4 to the local download directory.
+
+    The file is saved under ``SUPOCLIP_DOWNLOAD_DIR`` (default
+    ``./supoclip-downloads``). Requires authentication and task ownership.
+
+    Args:
+        task_id: The owning task id.
+        clip_id: The clip id to download.
+        filename: Optional output filename.
+
+    Returns:
+        str: JSON ``{"path": str, "filename": str, "bytes": int}`` — the absolute
+        local path of the saved MP4.
+    """
+    out_name = _safe_filename(filename or "", default=f"clip_{clip_id}.mp4")
+    result = await CLIENT.download(
+        f"/tasks/{task_id}/clips/{clip_id}/file", SETTINGS.download_dir, out_name
+    )
+    return _json(result)
+
+
+@mcp.tool(
+    name="supoclip_export_clip",
+    annotations={
+        "title": "Export Clip (Platform Preset)",
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_export_clip(
+    task_id: Annotated[str, Field(description="The task id that owns the clip.", min_length=1)],
+    clip_id: Annotated[str, Field(description="The clip id to export.", min_length=1)],
+    preset: Annotated[
+        ExportPreset,
+        Field(default="tiktok", description="Export preset: 'tiktok', 'reels' or 'shorts'."),
+    ] = "tiktok",
+    filename: Annotated[
+        Optional[str],
+        Field(default=None, description="Optional output filename; '.mp4' is enforced.", max_length=200),
+    ] = None,
+) -> str:
+    """Export a clip re-encoded for a social platform and save the MP4 locally.
+
+    Presets (tiktok/reels/shorts) produce 1080x1920 H.264 with platform-tuned
+    bitrates. Saved under ``SUPOCLIP_DOWNLOAD_DIR``. Requires authentication.
+
+    Args:
+        task_id: The owning task id.
+        clip_id: The clip id to export.
+        preset: 'tiktok' | 'reels' | 'shorts'.
+        filename: Optional output filename.
+
+    Returns:
+        str: JSON ``{"path": str, "filename": str, "bytes": int}``.
+    """
+    out_name = _safe_filename(filename or "", default=f"clip_{clip_id}_{preset}.mp4")
+    result = await CLIENT.download(
+        f"/tasks/{task_id}/clips/{clip_id}/export",
+        SETTINGS.download_dir,
+        out_name,
+        params={"preset": preset},
+    )
+    return _json(result)
+
+
+# --------------------------------------------------------------------------- #
+# Authenticated tools — management
+# --------------------------------------------------------------------------- #
+@mcp.tool(
+    name="supoclip_cancel_task",
+    annotations={
+        "title": "Cancel Task",
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_cancel_task(
+    task_id: Annotated[str, Field(description="The task id to cancel.", min_length=1)],
+) -> str:
+    """Cancel a queued or processing task. Requires authentication.
+
+    Args:
+        task_id: The task id to cancel.
+
+    Returns:
+        str: JSON ``{"message": str}``.
+    """
+    data = await CLIENT.request("POST", f"/tasks/{task_id}/cancel")
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_resume_task",
+    annotations={
+        "title": "Resume Task",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_resume_task(
+    task_id: Annotated[str, Field(description="The task id to resume.", min_length=1)],
+) -> str:
+    """Re-queue a cancelled or errored task for processing. Requires authentication.
+
+    Args:
+        task_id: The task id to resume.
+
+    Returns:
+        str: JSON ``{"message": str, "job_id": str}``.
+    """
+    data = await CLIENT.request("POST", f"/tasks/{task_id}/resume")
+    return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_delete_task",
+    annotations={
+        "title": "Delete Task",
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_delete_task(
+    task_id: Annotated[str, Field(description="The task id to delete.", min_length=1)],
+) -> str:
+    """Permanently delete a task and all of its generated clips.
+
+    This cannot be undone. Requires authentication and task ownership.
+
+    Args:
+        task_id: The task id to delete.
+
+    Returns:
+        str: JSON ``{"message": str}``.
+    """
+    data = await CLIENT.request("DELETE", f"/tasks/{task_id}")
+    return _json(data)
+
+
+def main() -> None:
+    """Console-script entry point: run the server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a standalone **MCP server** (`supoclip-mcp`, Python/FastMCP, stdio) under `mcp/` that exposes SupoClip to MCP clients (Claude Desktop/Code, Cursor, …). It's a thin client over the SupoClip REST API.

- **Default target:** the official hosted API `https://api.supoclip.com`. Override with `SUPOCLIP_API_URL` to self-host (e.g. `http://localhost:8000`).
- **Auth:** a per-user API key in `SUPOCLIP_API_KEY`. Self-hosters may instead use `SUPOCLIP_USER_ID` (+ `SUPOCLIP_AUTH_SECRET` when signing is enforced). Precedence: API key → signed headers → unsigned user id.
- **Downloads** are streamed to `SUPOCLIP_DOWNLOAD_DIR` (default `./supoclip-downloads`).

## Tools (16)
- **Tasks:** `create_clip_task`, `list_tasks`, `get_task`, `wait_for_task` (polls with progress), `cancel_task`, `resume_task`, `delete_task`
- **Clips:** `list_clips`, `download_clip`, `export_clip` (tiktok/reels/shorts presets)
- **Account:** `list_fonts`, `billing_summary`
- **Public discovery (no auth):** `health`, `list_caption_templates`, `list_transitions`, `broll_status`

Each tool has flat, validated input schemas (Pydantic `Field` constraints), annotations (read-only/destructive/idempotent hints), and actionable error messages (401/402/403/404/429 mapped to guidance).

## Testing
- Live against the hosted API: public tools return real data; missing-credential → friendly "set SUPOCLIP_API_KEY" error.
- All 16 tools register with clean flat schemas (no `ctx` leakage); packaged `supoclip-mcp` binary completes the MCP `initialize` handshake and serves `tools/list` over stdio.

## Run
```bash
cd mcp && uv run supoclip-mcp   # with SUPOCLIP_API_KEY set
```
See `mcp/README.md` for client config (Claude Desktop / `claude mcp add`).

## Dependency
Hosted authentication relies on the per-user API keys added in the companion PR (#61). The MCP code itself is independent (pure REST client); public discovery tools work without it.