### PR TITLE
fix(mcp): tolerate empty create task calls

### DIFF
--- a/mcp/src/supoclip_mcp/server.py
+++ b/mcp/src/supoclip_mcp/server.py
@@ -349,7 +349,7 @@ async def supoclip_billing_summary() -> str:
 )
 @tool_errors
 async def supoclip_create_clip_task(
-    url: str,
+    url: str = "",
     title: str = "",
     processing_mode: str = "fast",
     output_format: str = "vertical",
@@ -425,6 +425,27 @@ async def supoclip_create_clip_task(
 
     data = await _client().request("POST", "/tasks/", json_body=body)
     return _json(data)
+
+
+@mcp.tool(
+    name="supoclip_create_clip",
+    annotations={
+        "title": "Create Clip",
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+        "openWorldHint": True,
+    },
+)
+@tool_errors
+async def supoclip_create_clip(url: str = "") -> str:
+    """Create a SupoClip task from a YouTube or direct video URL.
+
+    This is a compatibility alias for clients that fail to pass arguments to
+    the richer ``supoclip_create_clip_task`` tool. Pass the video URL in the
+    ``url`` argument.
+    """
+    return await supoclip_create_clip_task(url=url)
 
 
 @mcp.tool(


### PR DESCRIPTION
## Summary
- make supoclip_create_clip_task tolerate empty argument objects instead of failing MCP validation
- add supoclip_create_clip as a minimal compatibility alias with a single url string

## Verification
- cd mcp && uv run python -m compileall src
- local list_tools shows no required field for create tools
- local empty call returns a normal missing-url message instead of a Pydantic validation error