### PR TITLE
fix(frontend): truncate clip transcripts

### DIFF
--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -56,6 +56,7 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/comp
 import { Progress } from "@/components/ui/progress";
 import Link from "next/link";
 import DynamicVideoPlayer from "@/components/dynamic-video-player";
+import { TranscriptPreview } from "@/components/transcript-preview";
 
 interface Clip {
   id: string;
@@ -899,10 +900,7 @@ export default function TaskPage() {
                             </div>
                           </div>
                           {clip.text && (
-                            <div className="mb-4">
-                              <h4 className="font-medium text-black mb-2">Transcript</h4>
-                              <p className="text-sm text-gray-700 bg-gray-50 p-3 rounded">{clip.text}</p>
-                            </div>
+                            <TranscriptPreview text={clip.text} clipTitle={`Clip ${clip.clip_order}`} />
                           )}
                           <Button size="sm" variant="outline" asChild>
                             <a href={getClipUrl(clip.video_url)} download={clip.filename}>
@@ -1270,10 +1268,7 @@ export default function TaskPage() {
                       )}
 
                       {clip.text && (
-                        <div className="mb-4">
-                          <h4 className="font-medium text-black mb-2">Transcript</h4>
-                          <p className="text-sm text-gray-700 bg-gray-50 p-3 rounded">{clip.text}</p>
-                        </div>
+                        <TranscriptPreview text={clip.text} clipTitle={`Clip ${clip.clip_order}`} />
                       )}
 
                       <div className="flex items-center gap-2">

--- a/frontend/src/components/transcript-preview.test.tsx
+++ b/frontend/src/components/transcript-preview.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, vi } from "vitest"
+
+import { TranscriptPreview } from "./transcript-preview"
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+it("opens the full transcript when the preview is truncated", async () => {
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(96)
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(144)
+  const user = userEvent.setup()
+
+  render(<TranscriptPreview text="A long transcript that continues beyond the preview." clipTitle="Launch clip" />)
+
+  await user.click(await screen.findByRole("button", { name: "See more" }))
+
+  expect(screen.getByRole("dialog")).toBeInTheDocument()
+  expect(screen.getByRole("heading", { name: "Full transcript" })).toBeInTheDocument()
+  expect(screen.getByText("Transcript for Launch clip")).toBeInTheDocument()
+})
+
+it("does not show a modal action when the whole transcript fits", () => {
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(96)
+  vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(96)
+
+  render(<TranscriptPreview text="A short transcript." />)
+
+  expect(screen.queryByRole("button", { name: "See more" })).not.toBeInTheDocument()
+})

--- a/frontend/src/components/transcript-preview.tsx
+++ b/frontend/src/components/transcript-preview.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+
+interface TranscriptPreviewProps {
+  text: string
+  clipTitle?: string | null
+}
+
+export function TranscriptPreview({ text, clipTitle }: TranscriptPreviewProps) {
+  const previewRef = useRef<HTMLParagraphElement>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  const measureTruncation = useCallback(() => {
+    const preview = previewRef.current
+    if (!preview) return
+
+    setIsTruncated(preview.scrollHeight > preview.clientHeight + 1)
+  }, [])
+
+  useEffect(() => {
+    measureTruncation()
+
+    const preview = previewRef.current
+    if (!preview || typeof ResizeObserver === "undefined") return
+
+    const observer = new ResizeObserver(measureTruncation)
+    observer.observe(preview)
+
+    return () => observer.disconnect()
+  }, [measureTruncation, text])
+
+  return (
+    <div className="mb-4">
+      <h4 className="mb-2 font-medium text-black">Transcript</h4>
+      <div className="rounded-lg bg-gray-50 p-3">
+        <p ref={previewRef} className="line-clamp-4 text-sm leading-6 text-gray-700">
+          {text}
+        </p>
+
+        {isTruncated && (
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="mt-2 rounded-sm text-sm font-medium text-gray-900 underline decoration-gray-300 underline-offset-4 transition-colors hover:decoration-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2"
+              >
+                See more
+              </button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Full transcript</DialogTitle>
+                <DialogDescription>
+                  {clipTitle ? `Transcript for ${clipTitle}` : "Complete transcript for this clip"}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="max-h-[60vh] overflow-y-auto rounded-lg bg-gray-50 p-4 text-sm leading-6 text-gray-700 whitespace-pre-wrap">
+                {text}
+              </div>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & { showCloseButton?: boolean }) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 grid w-[calc(100%-2rem)] max-w-2xl -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border bg-background p-6 shadow-xl duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-md p-1 text-muted-foreground opacity-70 transition-colors hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="dialog-header" className={cn("flex flex-col gap-1.5", className)} {...props} />
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg font-semibold leading-none", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}


### PR DESCRIPTION
## What changed

- Clamp clip transcript previews to four lines in both processing and completed clip cards
- Show a **See more** action only when the transcript actually overflows
- Open the complete transcript in an accessible, scrollable modal
- Add focused component tests for truncated and short transcript states

## Why

Long transcripts expanded clip cards far beyond the video height, making generated clip results difficult to scan. Keeping a compact preview preserves the card layout while retaining access to the complete transcript.

## Validation

- `pnpm exec vitest run src/components/transcript-preview.test.tsx`
- `pnpm exec eslint 'src/components/transcript-preview.tsx' 'src/components/transcript-preview.test.tsx' 'src/components/ui/dialog.tsx' 'src/app/tasks/[id]/page.tsx'`
- `git diff --check`
