### PR TITLE
feat(clips): add AI hook titles and subtle motion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,8 @@ Edit `backend/src/ai.py`: `simplified_system_prompt` controls selection criteria
 - Output: 9:16 vertical format, H.264, even pixel dimensions (`round_to_even()`)
 - Subtitles positioned at 75% down the frame
 - Virality scoring: `hook_score`, `engagement_score`, `value_score`, `shareability_score` (0-25 each, summed to `virality_score` 0-100)
+- Each segment gets an AI-written `hook_title` (3-9 words) burned into the top safe area for the first ~4s (`build_hook_title_ass` in `video_utils.py`), persisted on `generated_clips.hook_title`
+- Static talking-head crops get a slow ~5% Ken Burns punch-in (`kenburns_zoom_fragment`); tracked pans and split screens keep their own motion
 
 ## MCP Server
 

--- a/backend/src/ai.py
+++ b/backend/src/ai.py
@@ -23,7 +23,9 @@ IDEAL_CLIP_MIN_SECONDS = 25
 IDEAL_CLIP_MAX_SECONDS = 50
 MIN_ACCEPTED_CLIP_SECONDS = 15
 MAX_ACCEPTED_CLIP_SECONDS = 60
-TRANSCRIPT_ANALYSIS_CACHE_VERSION = "longer-clips-v3-duration-repair"
+TRANSCRIPT_ANALYSIS_CACHE_VERSION = "hook-titles-v4"
+HOOK_TITLE_MAX_CHARS = 64
+HOOK_TITLE_MAX_WORDS = 10
 TRANSCRIPT_SPAN_RE = re.compile(
     r"^\[(?P<start>\d{1,2}:\d{2}(?::\d{2})?)\s*-\s*"
     r"(?P<end>\d{1,2}:\d{2}(?::\d{2})?)\]\s*(?P<text>.*)$"
@@ -106,6 +108,14 @@ class TranscriptSegment(BaseModel):
         default_factory=_default_virality_analysis,
         description="Detailed virality score breakdown",
     )
+    hook_title: Optional[str] = Field(
+        default=None,
+        validation_alias=AliasChoices("hook_title", "title", "headline"),
+        description=(
+            "Short punchy on-screen title for the clip (3-9 words). Grounded in "
+            "the segment content, no hashtags, no emojis, no surrounding quotes."
+        ),
+    )
 
     @field_validator("relevance_score", mode="before")
     @classmethod
@@ -176,7 +186,7 @@ OUTPUT CONTRACT:
 - Return valid JSON only. Do not output Markdown, headings, bullets, prose, code fences, explanations, or commentary outside the JSON object.
 - The top-level JSON object must include: "most_relevant_segments", "summary", and "key_topics".
 - Only include "broll_opportunities" when B-roll was requested.
-- Each item in "most_relevant_segments" must include: "start_time", "end_time", "text", "relevance_score", "reasoning", and "virality".
+- Each item in "most_relevant_segments" must include: "start_time", "end_time", "text", "relevance_score", "reasoning", "virality", and "hook_title".
 - Do not use "segment" as an output field. Use "text".
 - "virality" must include: "hook_score", "engagement_score", "value_score", "shareability_score", "total_score", "hook_type", and "virality_reasoning".
 - Every returned segment must be 15-60 seconds long. Prefer 25-50 seconds.
@@ -246,6 +256,14 @@ For each segment, provide a detailed virality breakdown:
    - 15-19: Content worth bookmarking
    - 10-14: Nice but not share-worthy
    - 0-9: Generic content
+
+HOOK TITLES ("hook_title" per segment):
+- Write a short on-screen headline (3-9 words) that is burned into the top of the clip
+- It must make a scrolling viewer stop: a bold claim, curiosity gap, number, or stakes taken directly from the segment
+- Stay grounded: only promise what the clip actually delivers; never invent facts or numbers
+- Do not simply repeat the first spoken words verbatim; reframe them as a headline
+- Plain text only: no hashtags, no emojis, no quotes around the title
+- Good examples: "The $40k mistake I keep seeing", "Why nobody tells you this about VC", "Do this before your next interview"
 
 HOOK TYPES to identify:
 - "question": Opens with a question that creates curiosity
@@ -452,12 +470,44 @@ JSON-only output requirements:
 - Return one valid JSON object and nothing else.
 - No Markdown, headings, bullets, code fences, or explanatory text outside JSON.
 - Top-level keys: "most_relevant_segments", "summary", "key_topics"{', "broll_opportunities"' if include_broll else ''}.
-- Segment keys: "start_time", "end_time", "text", "relevance_score", "reasoning", "virality".
+- Segment keys: "start_time", "end_time", "text", "relevance_score", "reasoning", "virality", "hook_title".
+- "hook_title" is a 3-9 word plain-text headline for the clip, grounded in the segment (no hashtags, emojis, or quotes).
 - Virality keys: "hook_score", "engagement_score", "value_score", "shareability_score", "total_score", "hook_type", "virality_reasoning".
 - Do not return segments shorter than {MIN_ACCEPTED_CLIP_SECONDS} seconds or longer than {MAX_ACCEPTED_CLIP_SECONDS} seconds.
 
 Transcript:
 {transcript}"""
+
+
+def sanitize_hook_title(raw: Optional[str]) -> Optional[str]:
+    """Normalize an AI-provided hook title for on-screen rendering.
+
+    Strips wrapping quotes/markdown, collapses whitespace, drops hashtags, and
+    trims to a word-boundary length cap. Returns None when nothing usable is
+    left so callers can simply skip the overlay.
+    """
+    if not raw:
+        return None
+    title = str(raw).strip()
+    title = title.strip("\"'`“”‘’").strip()
+    title = re.sub(r"#\w+", "", title)
+    title = re.sub(r"\s+", " ", title).strip()
+    # Drop trailing sentence punctuation but keep ?/! (they carry the hook).
+    title = title.rstrip(".,;:-–— ").strip()
+    if not title:
+        return None
+
+    words = title.split()
+    if len(words) > HOOK_TITLE_MAX_WORDS:
+        words = words[:HOOK_TITLE_MAX_WORDS]
+        title = " ".join(words)
+    if len(title) > HOOK_TITLE_MAX_CHARS:
+        clipped = title[: HOOK_TITLE_MAX_CHARS + 1]
+        cut = clipped.rfind(" ")
+        title = (clipped[:cut] if cut > 20 else title[:HOOK_TITLE_MAX_CHARS]).rstrip(
+            ".,;:-–— "
+        )
+    return title or None
 
 
 def _parse_transcript_timestamp_seconds(timestamp: str) -> int:
@@ -703,6 +753,8 @@ async def get_most_relevant_parts_by_transcript(
                             f"Correcting virality total: {segment.virality.total_score} -> {calculated_total}"
                         )
                         segment.virality.total_score = calculated_total
+
+                segment.hook_title = sanitize_hook_title(segment.hook_title)
 
                 validated_segments.append(segment)
                 virality_info = (

--- a/backend/src/migrations/sql/20260704_0001_clip_hook_title.sql
+++ b/backend/src/migrations/sql/20260704_0001_clip_hook_title.sql
@@ -1,0 +1,2 @@
+-- AI-written on-screen hook titles for generated clips.
+ALTER TABLE generated_clips ADD COLUMN IF NOT EXISTS hook_title VARCHAR(200);

--- a/backend/src/repositories/clip_repository.py
+++ b/backend/src/repositories/clip_repository.py
@@ -32,6 +32,7 @@ class ClipRepository:
         value_score: int = 0,
         shareability_score: int = 0,
         hook_type: Optional[str] = None,
+        hook_title: Optional[str] = None,
     ) -> str:
         """Create a new clip record and return its ID."""
         try:
@@ -41,12 +42,12 @@ class ClipRepository:
                     (task_id, filename, file_path, start_time, end_time, duration,
                      text, relevance_score, reasoning, clip_order,
                      virality_score, hook_score, engagement_score, value_score, shareability_score, hook_type,
-                     created_at)
+                     hook_title, created_at)
                     VALUES
                     (:task_id, :filename, :file_path, :start_time, :end_time, :duration,
                      :text, :relevance_score, :reasoning, :clip_order,
                      :virality_score, :hook_score, :engagement_score, :value_score, :shareability_score, :hook_type,
-                     NOW())
+                     :hook_title, NOW())
                     RETURNING id
                 """),
                 {
@@ -66,6 +67,7 @@ class ClipRepository:
                     "value_score": value_score,
                     "shareability_score": shareability_score,
                     "hook_type": hook_type,
+                    "hook_title": hook_title,
                 },
             )
         except Exception:
@@ -107,7 +109,8 @@ class ClipRepository:
                 sa_text("""
                     SELECT id, filename, file_path, start_time, end_time, duration,
                            text, relevance_score, reasoning, clip_order, created_at,
-                           virality_score, hook_score, engagement_score, value_score, shareability_score, hook_type
+                           virality_score, hook_score, engagement_score, value_score, shareability_score, hook_type,
+                           hook_title
                     FROM generated_clips
                     WHERE task_id = :task_id
                     ORDER BY clip_order ASC
@@ -149,6 +152,7 @@ class ClipRepository:
                     "value_score": row.value_score or 0,
                     "shareability_score": row.shareability_score or 0,
                     "hook_type": row.hook_type,
+                    "hook_title": getattr(row, "hook_title", None),
                 }
             )
 
@@ -199,7 +203,7 @@ class ClipRepository:
                     SELECT id, task_id, filename, file_path, start_time, end_time, duration,
                            text, relevance_score, reasoning, clip_order,
                            virality_score, hook_score, engagement_score, value_score, shareability_score, hook_type,
-                           created_at
+                           hook_title, created_at
                     FROM generated_clips
                     WHERE id = :clip_id
                     """
@@ -241,6 +245,7 @@ class ClipRepository:
             "value_score": row.value_score or 0,
             "shareability_score": row.shareability_score or 0,
             "hook_type": row.hook_type,
+            "hook_title": getattr(row, "hook_title", None),
             "created_at": row.created_at.isoformat(),
             "video_url": f"/tasks/{row.task_id}/clips/{row.id}/file",
         }

--- a/backend/src/services/task_service.py
+++ b/backend/src/services/task_service.py
@@ -310,6 +310,7 @@ class TaskService:
                     value_score=clip_info.get("value_score", 0),
                     shareability_score=clip_info.get("shareability_score", 0),
                     hook_type=clip_info.get("hook_type"),
+                    hook_title=clip_info.get("hook_title"),
                 )
                 await self.db.commit()
                 clip_ids.append(clip_id)
@@ -633,6 +634,7 @@ class TaskService:
                     "value_score": clip.get("value_score", 0),
                     "shareability_score": clip.get("shareability_score", 0),
                     "hook_type": clip.get("hook_type"),
+                    "hook_title": clip.get("hook_title"),
                 }
             )
 
@@ -671,6 +673,7 @@ class TaskService:
                 value_score=clip_info.get("value_score", 0),
                 shareability_score=clip_info.get("shareability_score", 0),
                 hook_type=clip_info.get("hook_type"),
+                hook_title=clip_info.get("hook_title"),
             )
             clip_ids.append(clip_id)
 
@@ -774,6 +777,7 @@ class TaskService:
             value_score=clip.get("value_score", 0),
             shareability_score=clip.get("shareability_score", 0),
             hook_type=clip.get("hook_type"),
+            hook_title=clip.get("hook_title"),
         )
 
         await self.clip_repo.reorder_task_clips(self.db, task_id)

--- a/backend/src/services/video_service.py
+++ b/backend/src/services/video_service.py
@@ -88,6 +88,7 @@ class VideoService:
             "value_score": 0,
             "shareability_score": 0,
             "hook_type": "fallback",
+            "hook_title": None,
         }
 
     @staticmethod
@@ -272,6 +273,7 @@ class VideoService:
                 caption_template,
                 output_format,
                 keep_ranges,
+                segment.get("hook_title"),
             )
 
             if not success:
@@ -299,6 +301,7 @@ class VideoService:
                 "value_score": segment.get("value_score", 0),
                 "shareability_score": segment.get("shareability_score", 0),
                 "hook_type": segment.get("hook_type"),
+                "hook_title": segment.get("hook_title"),
                 "keep_ranges": keep_ranges,
             }
         except Exception as e:
@@ -486,6 +489,7 @@ class VideoService:
                             "value_score": virality.get("value_score", 0),
                             "shareability_score": virality.get("shareability_score", 0),
                             "hook_type": virality.get("hook_type"),
+                            "hook_title": segment.get("hook_title"),
                         }
                     )
                 else:
@@ -503,6 +507,7 @@ class VideoService:
                             "value_score": virality.get("value_score", 0),
                             "shareability_score": virality.get("shareability_score", 0),
                             "hook_type": virality.get("hook_type"),
+                            "hook_title": getattr(segment, "hook_title", None),
                         }
                     )
 

--- a/backend/src/video_utils.py
+++ b/backend/src/video_utils.py
@@ -30,7 +30,7 @@ from .clip_source_map import (
     save_clip_source_ranges,
 )
 from .caption_templates import get_template, CAPTION_TEMPLATES
-from .emoji_captions import annotate_caption_words
+from .emoji_captions import POWER_WORDS, annotate_caption_words, normalize_token
 from .font_registry import FONTS_DIR, find_font_path, get_font_family_name
 
 logger = logging.getLogger(__name__)
@@ -43,6 +43,11 @@ EMOJI_FONT_NAME = "Noto Color Emoji"
 CLIP_END_SENTENCE_EXTENSION_SECONDS = 3.0
 CLIP_END_PADDING_SECONDS = 0.35
 SENTENCE_END_RE = re.compile(r"""[.!?]["')\]}]*$""")
+# Burned-in hook title (AI-written headline shown at the top of the clip while
+# the hook plays out). Long enough to read twice, gone before it feels stale.
+HOOK_TITLE_SECONDS = 4.0
+HOOK_TITLE_MIN_SECONDS = 1.5
+HOOK_TITLE_TOP_MARGIN_FRAC = 0.07
 
 
 class VideoProcessor:
@@ -1309,6 +1314,103 @@ def extend_keep_ranges_to_sentence_boundary(
     return [*normalized[:-1], (last_start, extended_end)]
 
 
+def _balance_title_lines(words: List[str], max_chars: int) -> List[str]:
+    """Split title words into one line, or two lines balanced around the middle."""
+    text = " ".join(words)
+    if len(text) <= max_chars or len(words) < 2:
+        return [text]
+    best_lines = [text]
+    best_longest = len(text)
+    for i in range(1, len(words)):
+        first = " ".join(words[:i])
+        second = " ".join(words[i:])
+        longest = max(len(first), len(second))
+        if longest < best_longest:
+            best_longest = longest
+            best_lines = [first, second]
+    return best_lines
+
+
+def build_hook_title_ass(
+    hook_title: str,
+    template: Dict[str, Any],
+    video_width: int,
+    video_height: int,
+    output_duration: float,
+    font_name: str,
+    caption_font_px: int,
+) -> Tuple[str, List[str]]:
+    """Build the (style_line, dialogue_events) for a burned-in hook title.
+
+    The title sits in the top safe area (Alignment 8), styled off the caption
+    template so it reads as part of the same design system: same font, an
+    outline/backing for contrast, power words and numbers in the template's
+    highlight colour, and a quick fade+pop entrance.
+    """
+    uppercase = bool(template.get("uppercase"))
+    title_text = hook_title.upper() if uppercase else hook_title
+
+    primary = hex_to_ass_color(template.get("font_color"), "#FFFFFF")
+    highlight = hex_to_ass_color(
+        template.get("emphasis_color") or template.get("highlight_color"), "#FFE000"
+    )
+    outline = hex_to_ass_color(template.get("stroke_color") or "#000000", "#000000")
+    back_color = hex_to_ass_color(template.get("background_color"), "#00000080")
+
+    # Slightly smaller than the captions so the spoken words stay the hero.
+    base_px = max(34, min(66, int(caption_font_px * 0.82)))
+    usable_width = video_width - 2 * max(48, int(video_width * HOOK_TITLE_TOP_MARGIN_FRAC))
+    max_chars = max(10, int(usable_width / (base_px * 0.52)))
+    lines = _balance_title_lines(title_text.split(), max_chars)
+    longest = max(len(line) for line in lines)
+    hook_px = base_px
+    if longest > max_chars:
+        hook_px = max(30, min(base_px, int(usable_width / (longest * 0.52))))
+
+    base_stroke = int(template.get("stroke_width", 3) or 0)
+    has_outline = template.get("stroke_color") is not None and base_stroke > 0
+    border_style = 3 if (not has_outline and template.get("background_color")) else 1
+    outline_px = (
+        max(base_stroke, round(hook_px * base_stroke / 26)) if has_outline else 0
+    )
+    if border_style == 3:
+        outline_px = max(4, hook_px // 6)  # backing-box padding
+    elif outline_px == 0:
+        outline_px = max(2, hook_px // 16)  # always keep contrast on video
+    shadow_px = max(2, hook_px // 20) if template.get("shadow") else 0
+    margin_v = max(48, int(video_height * HOOK_TITLE_TOP_MARGIN_FRAC))
+
+    style_line = (
+        f"Style: Hook,{font_name},{hook_px},{primary},&H000000FF,{outline},{back_color},"
+        f"1,0,0,0,100,100,0,0,{border_style},{outline_px},{shadow_px},8,60,60,{margin_v},1"
+    )
+
+    # Accent power words / numbers in the template highlight colour.
+    rendered_lines: List[str] = []
+    for line in lines:
+        spans: List[str] = []
+        for word in line.split():
+            token = normalize_token(word)
+            accented = bool(token) and (token in POWER_WORDS or any(c.isdigit() for c in token))
+            color = highlight if accented else primary
+            spans.append(f"{{\\c{color}}}{escape_ass_text(word)}")
+        rendered_lines.append(" ".join(spans))
+    text = "\\N".join(rendered_lines)
+
+    start = 0.12
+    end = min(HOOK_TITLE_SECONDS, max(HOOK_TITLE_MIN_SECONDS, output_duration - 0.25))
+    if output_duration <= HOOK_TITLE_MIN_SECONDS:
+        start, end = 0.0, max(0.5, output_duration)
+    entrance = "\\fad(160,240)"
+    if template.get("word_pop", True):
+        entrance += "\\fscx90\\fscy90\\t(0,160,\\fscx100\\fscy100)"
+    events = [
+        f"Dialogue: 1,{ass_timestamp(start)},{ass_timestamp(end)},Hook,,0,0,0,,"
+        f"{{{entrance}}}{text}"
+    ]
+    return style_line, events
+
+
 def build_assemblyai_ass_subtitles(
     video_path: Path,
     clip_start: float,
@@ -1322,17 +1424,19 @@ def build_assemblyai_ass_subtitles(
     caption_template: str = "default",
     keep_ranges: Optional[List[Tuple[float, float]]] = None,
     caption_cues: Optional[List[Dict[str, Any]]] = None,
+    hook_title: Optional[str] = None,
+    include_captions: bool = True,
 ) -> bool:
     """Generate animated word-synced ASS subtitles from cached AssemblyAI words.
 
     Renders OpusClip-style captions: a per-word active highlight that pops, an
     accent colour on emphasised power/keyword words, contextual emojis, a thick
     scaled outline + drop shadow, and an optional pill behind the active word.
+    When ``hook_title`` is set, an AI-written headline is burned into the top
+    safe area while the hook plays out (it renders even when word-synced
+    captions are unavailable or disabled via ``include_captions``).
     """
     transcript_data = load_cached_transcript_data(video_path)
-    if not transcript_data or not transcript_data.get("words"):
-        logger.warning("No cached transcript data available for ASS subtitles")
-        return False
 
     template = get_template(caption_template)
     effective_font_family = font_family or template["font_family"]
@@ -1340,12 +1444,14 @@ def build_assemblyai_ass_subtitles(
     effective_font_color = font_color or template["font_color"]
     animation = template.get("animation", "karaoke")
 
-    if keep_ranges:
-        relevant_words = get_words_for_keep_ranges(transcript_data, keep_ranges)
-    else:
-        relevant_words = get_words_in_range(transcript_data, clip_start, clip_end)
-    if not relevant_words:
-        logger.warning("No words found in clip timerange for ASS subtitles")
+    relevant_words: List[Dict[str, Any]] = []
+    if include_captions and transcript_data and transcript_data.get("words"):
+        if keep_ranges:
+            relevant_words = get_words_for_keep_ranges(transcript_data, keep_ranges)
+        else:
+            relevant_words = get_words_in_range(transcript_data, clip_start, clip_end)
+    if not relevant_words and not hook_title:
+        logger.warning("No words or hook title available for ASS subtitles")
         return False
 
     # --- styling knobs (new template fields, all optional) ---
@@ -1382,6 +1488,28 @@ def build_assemblyai_ass_subtitles(
     font_name = ass_font_name(effective_font_family)
     border_style = 3 if template.get("background") and template.get("background_color") else 1
 
+    hook_style_block = ""
+    hook_events: List[str] = []
+    if hook_title:
+        if keep_ranges:
+            ranges = normalize_source_ranges(keep_ranges)
+            fade = crossfade_fade_for_ranges(ranges)
+            output_duration = sum(end - start for start, end in ranges) - fade * max(
+                0, len(ranges) - 1
+            )
+        else:
+            output_duration = max(0.0, clip_end - clip_start)
+        hook_style_line, hook_events = build_hook_title_ass(
+            hook_title,
+            template,
+            video_width,
+            video_height,
+            output_duration,
+            font_name,
+            font_px,
+        )
+        hook_style_block = f"{hook_style_line}\n"
+
     # Contextual emoji + emphasis annotations over the whole clip word list.
     emoji_by_idx, emphasis_idx = annotate_caption_words(
         relevant_words,
@@ -1403,7 +1531,7 @@ ScaledBorderAndShadow: yes
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
 Style: Default,{font_name},{font_px},{primary},&H000000FF,{outline},{back_color},1,0,0,0,100,100,0,0,{border_style},{outline_px},{shadow_px},5,60,60,60,1
-
+{hook_style_block}
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
 """
@@ -1508,8 +1636,14 @@ Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
                 f"Dialogue: 0,{ass_timestamp(start)},{ass_timestamp(end)},Default,,0,0,0,,{line_prefix}{effect}{chunk_text}"
             )
 
-    output_ass_path.write_text(header + "\n".join(events) + "\n", encoding="utf-8")
-    logger.info("Wrote ASS subtitles: %s (%d events)", output_ass_path, len(events))
+    all_events = hook_events + events
+    output_ass_path.write_text(header + "\n".join(all_events) + "\n", encoding="utf-8")
+    logger.info(
+        "Wrote ASS subtitles: %s (%d events%s)",
+        output_ass_path,
+        len(all_events),
+        ", hook title" if hook_events else "",
+    )
     return True
 
 
@@ -2232,6 +2366,38 @@ def build_layout_plan(
     ]
 
 
+# Ken Burns punch-in for static crops: a barely-perceptible push toward the
+# subject so locked-off talking-head clips still have life. Applied to static
+# crops only — tracked pans, split screens and content-shot compositing already
+# have their own motion.
+KENBURNS_ZOOM_DELTA = 0.05
+KENBURNS_MIN_SECONDS = 3.0
+KENBURNS_SUPERSAMPLE_W = 1620
+KENBURNS_SUPERSAMPLE_H = 2880
+
+
+def kenburns_zoom_fragment(duration: float) -> Optional[str]:
+    """Slow linear punch-in fragment producing a 1080x1920 [setsar-ed] stream.
+
+    Zooms through a 1.5x supersampled frame so zoompan's integer crop offsets
+    stay sub-pixel in the output (no visible stepping). The frame rate is
+    normalised to OUTPUT_FPS *before* zoompan and re-declared on it, because
+    zoompan re-times its output at its own fps — matching the two keeps the
+    video duration identical and the audio in sync.
+    """
+    if duration < KENBURNS_MIN_SECONDS:
+        return None
+    z_expr = (
+        f"if(isnan(it)\\,1\\,1+{KENBURNS_ZOOM_DELTA}*min(it/{duration:.3f}\\,1))"
+    )
+    return (
+        f"scale={KENBURNS_SUPERSAMPLE_W}:{KENBURNS_SUPERSAMPLE_H}:flags=lanczos,"
+        f"fps={OUTPUT_FPS},"
+        f"zoompan=z='{z_expr}':x='(iw-iw/zoom)/2':y='(ih-ih/zoom)*0.35'"
+        f":d=1:s=1080x1920:fps={OUTPUT_FPS},setsar=1"
+    )
+
+
 def build_vertical_compositor_filter(
     crop_chain: str,
     face_intervals: List[Tuple[float, float]],
@@ -2282,13 +2448,12 @@ def build_vertical_filter_plan(
     crop_w, crop_h = compute_vertical_crop_dims(width, height)
     duration = ffprobe_duration(input_path)
 
-    # Narrow/portrait source: no horizontal room to crop — static fit.
+    # Narrow/portrait source: no horizontal room to crop — static fit, with a
+    # slow punch-in so the frame still breathes.
     if crop_w >= width:
         sx, sy, sw, sh = detect_optimal_crop_region(input_path, 0, min(duration, 12.0))
-        return (
-            f"crop={sw}:{sh}:{sx}:{sy},scale=1080:1920:flags=lanczos,setsar=1",
-            "vf",
-        )
+        tail = kenburns_zoom_fragment(duration) or "scale=1080:1920:flags=lanczos,setsar=1"
+        return (f"crop={sw}:{sh}:{sx}:{sy},{tail}", "vf")
 
     # One fast decode pass yields both the face track and the scene cuts.
     try:
@@ -2298,7 +2463,9 @@ def build_vertical_filter_plan(
         track, scene_cuts = [], []
 
     keys = build_crop_trajectory(track, width, crop_w) if track else []
-    if keys and trajectory_has_movement(keys, crop_w):
+    moving = bool(keys and trajectory_has_movement(keys, crop_w))
+    static_x = 0
+    if moving:
         x_expr = build_smooth_pan_expression(keys)
         crop_chain = (
             f"crop={crop_w}:{crop_h}:x='{x_expr}':y=0,"
@@ -2320,6 +2487,13 @@ def build_vertical_filter_plan(
     plan = build_layout_plan(track, scene_cuts, duration)
     fit_intervals = [(s["start"], s["end"]) for s in plan if s["kind"] == "fit"]
     if not fit_intervals:
+        # Static, all-face clip: add the slow Ken Burns punch-in. (The moving
+        # tracked crop and the compositor path keep the plain chain — they
+        # already have motion, and zoompan's re-timing would fight overlays.)
+        if not moving:
+            zoom = kenburns_zoom_fragment(duration)
+            if zoom:
+                return (f"crop={crop_w}:{crop_h}:{static_x}:0,{zoom}", "vf")
         return (crop_chain, "vf")
 
     face_intervals = [(s["start"], s["end"]) for s in plan if s["kind"] == "face"]
@@ -2943,6 +3117,7 @@ def create_optimized_clip(
     caption_template: str = "default",
     output_format: str = "vertical",
     keep_ranges: Optional[List[Tuple[float, float]]] = None,
+    hook_title: Optional[str] = None,
 ) -> bool:
     """Create clip with optional subtitles. output_format: 'vertical' (9:16) or 'original' (keep source size)."""
     try:
@@ -3022,7 +3197,7 @@ def create_optimized_clip(
 
             burn_ass_path: Optional[Path] = None
             fonts_dir: Optional[Path] = None
-            if add_subtitles and build_assemblyai_ass_subtitles(
+            if (add_subtitles or hook_title) and build_assemblyai_ass_subtitles(
                 video_path,
                 start_time,
                 end_time,
@@ -3034,6 +3209,8 @@ def create_optimized_clip(
                 font_color,
                 caption_template,
                 effective_keep_ranges,
+                hook_title=hook_title,
+                include_captions=add_subtitles,
             ):
                 burn_ass_path = ass_path
                 fonts_dir = ass_fonts_dir(
@@ -3141,6 +3318,7 @@ def create_clips_from_segments(
                 caption_template,
                 output_format,
                 keep_ranges,
+                hook_title=segment.get("hook_title"),
             )
 
             if success:
@@ -3163,6 +3341,7 @@ def create_clips_from_segments(
                     "value_score": segment.get("value_score", 0),
                     "shareability_score": segment.get("shareability_score", 0),
                     "hook_type": segment.get("hook_type"),
+                    "hook_title": segment.get("hook_title"),
                     "keep_ranges": keep_ranges,
                 }
                 clips_info.append(clip_info)

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -77,6 +77,7 @@ interface Clip {
   value_score: number;
   shareability_score: number;
   hook_type: string | null;
+  hook_title: string | null;
 }
 
 interface TaskDetails {
@@ -878,8 +879,12 @@ export default function TaskPage() {
                         <div className="p-6 flex-1">
                           <div className="flex items-start justify-between mb-4">
                             <div>
-                              <h3 className="font-semibold text-lg text-black mb-1">Clip {clip.clip_order}</h3>
+                              <h3 className="font-semibold text-lg text-black mb-1">
+                                {clip.hook_title || `Clip ${clip.clip_order}`}
+                              </h3>
                               <div className="flex items-center gap-2 text-sm text-gray-600">
+                                <span>Clip {clip.clip_order}</span>
+                                <span>•</span>
                                 <span>{clip.start_time} - {clip.end_time}</span>
                                 <span>•</span>
                                 <span>{formatDuration(clip.duration)}</span>
@@ -1172,8 +1177,12 @@ export default function TaskPage() {
                             />
                             Select for merge
                           </label>
-                          <h3 className="font-semibold text-lg text-black mb-1">Clip {clip.clip_order}</h3>
+                          <h3 className="font-semibold text-lg text-black mb-1">
+                            {clip.hook_title || `Clip ${clip.clip_order}`}
+                          </h3>
                           <div className="flex items-center gap-2 text-sm text-gray-600">
+                            <span>Clip {clip.clip_order}</span>
+                            <span>•</span>
                             <span>
                               {clip.start_time} - {clip.end_time}
                             </span>

--- a/init.sql
+++ b/init.sql
@@ -96,6 +96,7 @@ CREATE TABLE generated_clips (
     value_score INTEGER DEFAULT 0,
     shareability_score INTEGER DEFAULT 0,
     hook_type VARCHAR(50),
+    hook_title VARCHAR(200),         -- AI-written on-screen headline
 
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP


### PR DESCRIPTION
## What changed

- generate and sanitize short AI hook titles for each selected clip
- persist hook titles through the service and repository layers with a database migration
- burn hook titles into the top safe area during the opening seconds
- display hook titles in the task clip UI
- add a subtle Ken Burns punch-in for otherwise static talking-head crops
- document hook-title and static-motion behavior in CLAUDE.md

## Why

Give generated clips a stronger opening visual hook and add restrained motion to static crops without interfering with tracked pans or split-screen layouts.

## Impact

Existing databases need the included hook_title migration. Newly generated clips can carry an AI-written title in API responses, storage, the task UI, and rendered video.

## Validation

- `uv run python -m compileall -q src`
- `npm run lint`