### PR TITLE
feat(email): notify users of new API keys

### DIFF
--- a/backend/src/api/routes/api_keys.py
+++ b/backend/src/api/routes/api_keys.py
@@ -9,11 +9,14 @@ with an API key) so that a leaked key cannot be used to create more keys.
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ...auth_headers import get_authenticated_user_id
 from ...config import get_config
 from ...database import get_db
+from ...models import User
+from ...services.api_key_email_service import ApiKeyEmailService
 from ...services.api_key_service import ApiKeyLimitExceeded, ApiKeyService
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,31 @@ async def create_api_key(request: Request, db: AsyncSession = Depends(get_db)):
     except Exception as exc:  # pragma: no cover - defensive
         logger.error("Error creating API key: %s", exc)
         raise HTTPException(status_code=500, detail="Error creating API key")
+
+    try:
+        user_result = await db.execute(select(User).where(User.id == user_id))
+        user = user_result.scalar_one_or_none()
+        email_service = ApiKeyEmailService(get_config())
+        if not user:
+            logger.warning(
+                "API key %s was created but user %s could not be loaded for notification",
+                created.get("id"),
+                user_id,
+            )
+        elif not email_service.is_configured:
+            logger.warning(
+                "API key %s was created for user %s but SES is not configured",
+                created.get("id"),
+                user_id,
+            )
+        else:
+            await email_service.send_created_email(user, created)
+    except Exception:
+        logger.exception(
+            "Failed to send API key creation email for key %s and user %s",
+            created.get("id"),
+            user_id,
+        )
 
     return {"api_key": created, "message": "API key created. Copy it now — it won't be shown again."}
 

--- a/backend/src/services/api_key_email_service.py
+++ b/backend/src/services/api_key_email_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from html import escape
+from typing import Any, Mapping, Optional
+
+from ..config import Config
+from ..models import User
+from .email_service import EmailContent, SesEmailService, first_name_for
+
+
+class ApiKeyEmailService:
+    """Send security notifications for API-key lifecycle events."""
+
+    def __init__(self, config: Optional[Config] = None):
+        self.config = config or Config()
+        self.email_service = SesEmailService(self.config)
+
+    @property
+    def is_configured(self) -> bool:
+        return self.email_service.is_configured
+
+    async def send_created_email(
+        self, user: User, api_key: Mapping[str, Any]
+    ) -> dict:
+        content = self._build_created_email(user, api_key)
+        return await self.email_service.send_email(user.email, content)
+
+    def _build_created_email(
+        self, user: User, api_key: Mapping[str, Any]
+    ) -> EmailContent:
+        first_name = first_name_for(first_name=user.first_name, full_name=user.name)
+        key_name = str(api_key.get("name") or "API Key")
+        key_prefix = str(api_key.get("key_prefix") or "unknown")
+
+        return EmailContent(
+            subject="A new SupoClip API key was created",
+            html=(
+                f"<p>Hi {escape(first_name)},</p>"
+                "<p>A new API key was created for your SupoClip account.</p>"
+                f"<p><strong>Name:</strong> {escape(key_name)}<br>"
+                f"<strong>Prefix:</strong> {escape(key_prefix)}</p>"
+                "<p>If you created this key, no action is needed. If you did not, "
+                "revoke it immediately from your SupoClip API key settings and secure your account.</p>"
+                "<p>For your security, the API key secret is not included in this email.</p>"
+                "<p>Team SupoClip</p>"
+            ),
+            text=(
+                f"Hi {first_name},\n\n"
+                "A new API key was created for your SupoClip account.\n\n"
+                f"Name: {key_name}\n"
+                f"Prefix: {key_prefix}\n\n"
+                "If you created this key, no action is needed. If you did not, revoke it "
+                "immediately from your SupoClip API key settings and secure your account.\n\n"
+                "For your security, the API key secret is not included in this email.\n\n"
+                "Team SupoClip"
+            ),
+        )

--- a/backend/tests/unit/test_api_key_email_service.py
+++ b/backend/tests/unit/test_api_key_email_service.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.services.api_key_email_service import ApiKeyEmailService
+
+
+def configured_service() -> ApiKeyEmailService:
+    config = SimpleNamespace(
+        aws_region="eu-central-1",
+        aws_access_key_id="access-key",
+        aws_secret_access_key="secret-key",
+        ses_from_email="SupoClip <noreply@example.com>",
+    )
+    return ApiKeyEmailService(config)
+
+
+def test_created_email_contains_metadata_but_not_secret():
+    service = configured_service()
+    user = SimpleNamespace(
+        email="user@example.com", first_name="Ada", name="Ada Lovelace"
+    )
+    api_key = {
+        "name": "Automation",
+        "key_prefix": "sk_abc12345",
+        "key": "sk_abc12345_super-secret-value",
+    }
+
+    content = service._build_created_email(user, api_key)
+
+    assert content.subject == "A new SupoClip API key was created"
+    assert "Automation" in content.html
+    assert "sk_abc12345" in content.text
+    assert api_key["key"] not in content.html
+    assert api_key["key"] not in content.text
+
+
+def test_created_email_escapes_user_controlled_html():
+    service = configured_service()
+    user = SimpleNamespace(
+        email="user@example.com", first_name="<Ada>", name="Ada Lovelace"
+    )
+
+    content = service._build_created_email(
+        user, {"name": "<script>alert(1)</script>", "key_prefix": "sk_safe"}
+    )
+
+    assert "<script>" not in content.html
+    assert "&lt;script&gt;" in content.html
+    assert "&lt;Ada&gt;" in content.html
+
+
+@pytest.mark.asyncio
+async def test_send_created_email_uses_users_email():
+    service = configured_service()
+    service.email_service.send_email = AsyncMock(return_value={"MessageId": "email-1"})
+    user = SimpleNamespace(
+        email="user@example.com", first_name=None, name="Ada Lovelace"
+    )
+
+    result = await service.send_created_email(
+        user, {"name": "Automation", "key_prefix": "sk_abc12345"}
+    )
+
+    assert result == {"MessageId": "email-1"}
+    service.email_service.send_email.assert_awaited_once()
+    assert service.email_service.send_email.await_args.args[0] == "user@example.com"


### PR DESCRIPTION
## What changed

- send an Amazon SES security notification after a user creates an API key
- include only the key name and visible prefix, never the plaintext secret
- escape user-controlled values in the HTML email
- keep notification delivery best-effort so email failures do not invalidate a persisted key
- add focused tests for content safety and delivery behavior

## Why

Users should be alerted when credentials are created for their account so unexpected activity can be detected and revoked quickly.

## Validation

- Python compilation passed for the changed modules and test file
- standalone email safety checks passed
- `git diff --check` passed
- focused pytest collection is currently blocked by the repository dependency mismatch between `pydantic-ai` and `griffe`