### PR TITLE
feat(fonts): allow users to delete custom fonts

### DIFF
--- a/backend/src/api/routes/media.py
+++ b/backend/src/api/routes/media.py
@@ -198,7 +198,7 @@ async def delete_font(
             raise HTTPException(status_code=404, detail="Custom font not found")
 
         deleted_name = font_path.stem
-        font_path.unlink()
+        font_path.unlink(missing_ok=True)
         logger.info("Deleted custom font %s for user %s", font_path.name, user_id)
         return {"font_name": deleted_name, "message": "Font deleted successfully"}
     except HTTPException:

--- a/backend/src/api/routes/media.py
+++ b/backend/src/api/routes/media.py
@@ -19,6 +19,7 @@ from ...font_registry import (
     SUPPORTED_FONT_EXTENSIONS,
     build_user_font_stem,
     find_font_path,
+    find_user_font_path,
     get_available_fonts as list_available_fonts,
     get_user_fonts_dir,
     sanitize_font_stem,
@@ -178,6 +179,33 @@ async def upload_font(
     except Exception as e:
         logger.error(f"Error uploading font: {str(e)}")
         raise HTTPException(status_code=500, detail=f"Error uploading font: {str(e)}")
+
+
+@router.delete("/fonts/{font_name}")
+async def delete_font(
+    font_name: str, request: Request, db: AsyncSession = Depends(get_db)
+):
+    """Delete a custom font owned by the authenticated user."""
+    try:
+        user_id = await _get_authenticated_user_id(request, db)
+        font_path = find_user_font_path(font_name, user_id)
+
+        if font_path is None:
+            if find_font_path(font_name) is not None:
+                raise HTTPException(
+                    status_code=403, detail="Bundled system fonts cannot be deleted"
+                )
+            raise HTTPException(status_code=404, detail="Custom font not found")
+
+        deleted_name = font_path.stem
+        font_path.unlink()
+        logger.info("Deleted custom font %s for user %s", font_path.name, user_id)
+        return {"font_name": deleted_name, "message": "Font deleted successfully"}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error deleting font %s: %s", font_name, e)
+        raise HTTPException(status_code=500, detail=f"Error deleting font: {str(e)}")
 
 
 @router.get("/transitions")

--- a/backend/src/font_registry.py
+++ b/backend/src/font_registry.py
@@ -23,6 +23,31 @@ def get_user_fonts_dir(user_id: str) -> Path:
     return USER_FONTS_DIR / sanitize_user_id_for_path(user_id)
 
 
+def find_user_font_path(font_name: str, user_id: str) -> Path | None:
+    """Resolve an exact font name inside one user's upload directory only."""
+    requested = font_name.strip()
+    if not requested or Path(requested).name != requested:
+        return None
+
+    user_fonts_dir = get_user_fonts_dir(user_id)
+    exact_file = user_fonts_dir / requested
+    if (
+        exact_file.is_file()
+        and exact_file.suffix.lower() in SUPPORTED_FONT_EXTENSIONS
+    ):
+        return exact_file
+
+    if Path(requested).suffix:
+        return None
+
+    for extension in SUPPORTED_FONT_EXTENSIONS:
+        candidate = user_fonts_dir / f"{requested}{extension}"
+        if candidate.is_file():
+            return candidate
+
+    return None
+
+
 def _collect_fonts_from_dir(font_dir: Path, scope: str) -> list[dict[str, Any]]:
     if not font_dir.exists():
         return []

--- a/backend/tests/unit/test_media_font_deletion.py
+++ b/backend/tests/unit/test_media_font_deletion.py
@@ -56,6 +56,41 @@ async def test_delete_font_cannot_delete_another_users_upload(
 
 
 @pytest.mark.asyncio
+async def test_delete_font_accepts_full_filename(monkeypatch, isolated_font_dirs):
+    _, user_root = isolated_font_dirs
+    owned_font = user_root / "user-1" / "usr-user-1-brand.ttf"
+    owned_font.parent.mkdir()
+    owned_font.write_bytes(b"font")
+    monkeypatch.setattr(
+        media, "_get_authenticated_user_id", AsyncMock(return_value="user-1")
+    )
+
+    response = await media.delete_font("usr-user-1-brand.ttf", object(), object())
+
+    assert response["font_name"] == "usr-user-1-brand"
+    assert not owned_font.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_font_rejects_path_traversal(monkeypatch, isolated_font_dirs):
+    _, user_root = isolated_font_dirs
+    other_font = user_root / "user-2" / "usr-user-2-brand.ttf"
+    other_font.parent.mkdir()
+    other_font.write_bytes(b"font")
+    monkeypatch.setattr(
+        media, "_get_authenticated_user_id", AsyncMock(return_value="user-1")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media.delete_font(
+            "../user-2/usr-user-2-brand.ttf", object(), object()
+        )
+
+    assert exc_info.value.status_code == 404
+    assert other_font.exists()
+
+
+@pytest.mark.asyncio
 async def test_delete_font_rejects_bundled_system_font(
     monkeypatch, isolated_font_dirs
 ):

--- a/backend/tests/unit/test_media_font_deletion.py
+++ b/backend/tests/unit/test_media_font_deletion.py
@@ -1,0 +1,87 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from src import font_registry
+from src.api.routes import media
+
+
+@pytest.fixture()
+def isolated_font_dirs(monkeypatch, tmp_path):
+    system_dir = tmp_path / "system-fonts"
+    user_dir = tmp_path / "user-fonts"
+    system_dir.mkdir()
+    user_dir.mkdir()
+    monkeypatch.setattr(font_registry, "FONTS_DIR", system_dir)
+    monkeypatch.setattr(font_registry, "USER_FONTS_DIR", user_dir)
+    return system_dir, user_dir
+
+
+@pytest.mark.asyncio
+async def test_delete_font_removes_only_the_authenticated_users_upload(
+    monkeypatch, isolated_font_dirs
+):
+    _, user_root = isolated_font_dirs
+    owned_font = user_root / "user-1" / "usr-user-1-brand.ttf"
+    owned_font.parent.mkdir()
+    owned_font.write_bytes(b"font")
+    monkeypatch.setattr(
+        media, "_get_authenticated_user_id", AsyncMock(return_value="user-1")
+    )
+
+    response = await media.delete_font("usr-user-1-brand", object(), object())
+
+    assert response["font_name"] == "usr-user-1-brand"
+    assert not owned_font.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_font_cannot_delete_another_users_upload(
+    monkeypatch, isolated_font_dirs
+):
+    _, user_root = isolated_font_dirs
+    other_font = user_root / "user-2" / "usr-user-2-brand.ttf"
+    other_font.parent.mkdir()
+    other_font.write_bytes(b"font")
+    monkeypatch.setattr(
+        media, "_get_authenticated_user_id", AsyncMock(return_value="user-1")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media.delete_font("usr-user-2-brand", object(), object())
+
+    assert exc_info.value.status_code == 404
+    assert other_font.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_font_rejects_bundled_system_font(
+    monkeypatch, isolated_font_dirs
+):
+    system_dir, _ = isolated_font_dirs
+    system_font = system_dir / "Inter.ttf"
+    system_font.write_bytes(b"font")
+    monkeypatch.setattr(
+        media, "_get_authenticated_user_id", AsyncMock(return_value="user-1")
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media.delete_font("Inter", object(), object())
+
+    assert exc_info.value.status_code == 403
+    assert system_font.exists()
+
+
+@pytest.mark.asyncio
+async def test_delete_font_requires_authentication(monkeypatch, isolated_font_dirs):
+    monkeypatch.setattr(
+        media,
+        "_get_authenticated_user_id",
+        AsyncMock(side_effect=HTTPException(status_code=401, detail="Unauthorized")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await media.delete_font("usr-user-1-brand", object(), object())
+
+    assert exc_info.value.status_code == 401

--- a/frontend/src/app/api/fonts/[fontName]/route.test.ts
+++ b/frontend/src/app/api/fonts/[fontName]/route.test.ts
@@ -1,0 +1,72 @@
+import { headers } from "next/headers";
+
+import { auth } from "@/lib/auth";
+import { buildBackendAuthHeaders } from "@/lib/backend-auth";
+
+import { DELETE } from "./route";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      getSession: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/backend-auth", () => ({
+  buildBackendAuthHeaders: vi.fn(),
+}));
+
+describe("DELETE /api/fonts/[fontName]", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(headers).mockResolvedValue(new Headers() as never);
+    vi.mocked(buildBackendAuthHeaders).mockReturnValue({
+      "x-supoclip-user-id": "user-1",
+    });
+    process.env.BACKEND_INTERNAL_URL = "http://backend:8000";
+  });
+
+  it("returns 401 without an authenticated session", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await DELETE(new Request("http://localhost/api/fonts/Inter"), {
+      params: Promise.resolve({ fontName: "Inter" }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards an owner-authenticated delete request to the backend", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "user-1" },
+    } as never);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "Font deleted successfully" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await DELETE(new Request("http://localhost/api/fonts/Brand%20Font"), {
+      params: Promise.resolve({ fontName: "Brand Font" }),
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://backend:8000/fonts/Brand%20Font",
+      expect.objectContaining({
+        method: "DELETE",
+        headers: { "x-supoclip-user-id": "user-1" },
+      }),
+    );
+    expect(response.status).toBe(200);
+  });
+});

--- a/frontend/src/app/api/fonts/[fontName]/route.ts
+++ b/frontend/src/app/api/fonts/[fontName]/route.ts
@@ -64,21 +64,12 @@ export async function DELETE(_: Request, { params }: Params) {
   const encodedFontName = encodeURIComponent(fontName);
   const backendAuthHeaders = buildBackendAuthHeaders(session.user.id);
 
-  let upstream = await fetch(`${normalizedApiUrl}/fonts/${encodedFontName}`, {
+  const upstream = await fetch(`${normalizedApiUrl}/fonts/${encodedFontName}`, {
     method: "DELETE",
     headers: {
       ...backendAuthHeaders,
     },
   });
-
-  if (upstream.status === 404) {
-    upstream = await fetch(`${normalizedApiUrl}/api/fonts/${encodedFontName}`, {
-      method: "DELETE",
-      headers: {
-        ...backendAuthHeaders,
-      },
-    });
-  }
 
   const responseText = await upstream.text();
   return new NextResponse(responseText, {

--- a/frontend/src/app/api/fonts/[fontName]/route.ts
+++ b/frontend/src/app/api/fonts/[fontName]/route.ts
@@ -48,3 +48,43 @@ export async function GET(_: Request, { params }: Params) {
     },
   });
 }
+
+export async function DELETE(_: Request, { params }: Params) {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { fontName } = await params;
+  const apiUrl =
+    process.env.BACKEND_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "http://localhost:8000";
+  const normalizedApiUrl = apiUrl.replace(/\/$/, "");
+  const encodedFontName = encodeURIComponent(fontName);
+  const backendAuthHeaders = buildBackendAuthHeaders(session.user.id);
+
+  let upstream = await fetch(`${normalizedApiUrl}/fonts/${encodedFontName}`, {
+    method: "DELETE",
+    headers: {
+      ...backendAuthHeaders,
+    },
+  });
+
+  if (upstream.status === 404) {
+    upstream = await fetch(`${normalizedApiUrl}/api/fonts/${encodedFontName}`, {
+      method: "DELETE",
+      headers: {
+        ...backendAuthHeaders,
+      },
+    });
+  }
+
+  const responseText = await upstream.text();
+  return new NextResponse(responseText, {
+    status: upstream.status,
+    headers: {
+      "Content-Type": upstream.headers.get("content-type") || "application/json",
+    },
+  });
+}

--- a/frontend/src/app/tasks/[id]/page.tsx
+++ b/frontend/src/app/tasks/[id]/page.tsx
@@ -49,7 +49,6 @@ import {
   RefreshCw,
   Subtitles,
   Settings2,
-  Type,
   Clapperboard,
 } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
@@ -57,6 +56,7 @@ import { Progress } from "@/components/ui/progress";
 import Link from "next/link";
 import DynamicVideoPlayer from "@/components/dynamic-video-player";
 import { TranscriptPreview } from "@/components/transcript-preview";
+import { FontSelectOption, type FontOption } from "@/components/font-select-option";
 
 interface Clip {
   id: string;
@@ -104,11 +104,6 @@ interface TaskDetails {
   filtered_words?: string[];
 }
 
-interface FontOption {
-  name: string;
-  display_name: string;
-}
-
 export default function TaskPage() {
   const params = useParams();
   const router = useRouter();
@@ -146,6 +141,7 @@ export default function TaskPage() {
   const [isApplyingSettings, setIsApplyingSettings] = useState(false);
   const [settingsSheetOpen, setSettingsSheetOpen] = useState(false);
   const [availableFonts, setAvailableFonts] = useState<FontOption[]>([]);
+  const [deletingFontName, setDeletingFontName] = useState<string | null>(null);
   const [availableTemplates, setAvailableTemplates] = useState<
     Array<{ id: string; name: string; description: string; animation: string }>
   >([]);
@@ -601,6 +597,34 @@ export default function TaskPage() {
     }
   };
 
+  const handleDeleteFont = async (font: FontOption) => {
+    if (font.scope !== "user" || deletingFontName) return;
+    if (!window.confirm(`Delete ${font.display_name}? This cannot be undone.`)) return;
+
+    setDeletingFontName(font.name);
+    try {
+      const response = await fetch(`/api/fonts/${encodeURIComponent(font.name)}`, {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error(await buildSupportError(response, "Failed to delete font"));
+      }
+
+      const remainingFonts = availableFonts.filter((item) => item.name !== font.name);
+      setAvailableFonts(remainingFonts);
+      if (projectFontFamily === font.name) {
+        setProjectFontFamily(
+          remainingFonts.find((item) => item.scope === "system")?.name ||
+            "TikTokSans-Regular",
+        );
+      }
+    } catch (deleteError) {
+      alert(deleteError instanceof Error ? deleteError.message : "Failed to delete font");
+    } finally {
+      setDeletingFontName(null);
+    }
+  };
+
   const handleExportClip = async (clipId: string, fallbackFilename: string) => {
     if (!session?.user?.id || !task?.id) return;
 
@@ -1014,12 +1038,12 @@ export default function TaskPage() {
                       </SelectTrigger>
                       <SelectContent>
                         {availableFonts.map((font) => (
-                          <SelectItem key={font.name} value={font.name}>
-                            <span className="flex items-center gap-2">
-                              <Type className="w-3 h-3" />
-                              {font.display_name}
-                            </span>
-                          </SelectItem>
+                          <FontSelectOption
+                            key={font.name}
+                            font={font}
+                            isDeleting={deletingFontName === font.name}
+                            onDelete={handleDeleteFont}
+                          />
                         ))}
                         {availableFonts.length === 0 && (
                           <SelectItem value="TikTokSans-Regular">TikTok Sans Regular</SelectItem>

--- a/frontend/src/components/font-select-option.test.tsx
+++ b/frontend/src/components/font-select-option.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { FontSelectOption } from "./font-select-option";
+
+vi.mock("@/components/ui/select", () => ({
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+describe("FontSelectOption", () => {
+  it("shows a delete action for a user-uploaded font", () => {
+    const onDelete = vi.fn();
+    const font = {
+      name: "usr-user-1-brand-font",
+      display_name: "Brand Font",
+      scope: "user" as const,
+    };
+
+    render(<FontSelectOption font={font} isDeleting={false} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Brand Font" }));
+
+    expect(onDelete).toHaveBeenCalledWith(font);
+  });
+
+  it("does not offer deletion for bundled system fonts", () => {
+    render(
+      <FontSelectOption
+        font={{ name: "Inter", display_name: "Inter", scope: "system" }}
+        isDeleting={false}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /delete/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/font-select-option.tsx
+++ b/frontend/src/components/font-select-option.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Trash2, Type } from "lucide-react";
+
+import { SelectItem } from "@/components/ui/select";
+
+export interface FontOption {
+  name: string;
+  display_name: string;
+  scope: "system" | "user";
+}
+
+interface FontSelectOptionProps {
+  font: FontOption;
+  isDeleting: boolean;
+  onDelete: (font: FontOption) => void;
+}
+
+export function FontSelectOption({
+  font,
+  isDeleting,
+  onDelete,
+}: FontSelectOptionProps) {
+  return (
+    <div className="flex items-center gap-1" data-font-scope={font.scope}>
+      <SelectItem className="min-w-0 flex-1" value={font.name}>
+        <span className="flex min-w-0 items-center gap-2">
+          <Type className="h-3 w-3" />
+          <span className="truncate">{font.display_name}</span>
+        </span>
+      </SelectItem>
+      {font.scope === "user" && (
+        <button
+          type="button"
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-sm text-gray-500 hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50"
+          aria-label={`Delete ${font.display_name}`}
+          title={`Delete ${font.display_name}`}
+          disabled={isDeleting}
+          onPointerDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onDelete(font);
+          }}
+        >
+          <Trash2 className="h-4 w-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/font-select-option.tsx
+++ b/frontend/src/components/font-select-option.tsx
@@ -22,7 +22,7 @@ export function FontSelectOption({
   onDelete,
 }: FontSelectOptionProps) {
   return (
-    <div className="flex items-center gap-1" data-font-scope={font.scope}>
+    <div className="flex items-center gap-1">
       <SelectItem className="min-w-0 flex-1" value={font.name}>
         <span className="flex min-w-0 items-center gap-2">
           <Type className="h-3 w-3" />


### PR DESCRIPTION
## Summary

- add an authenticated `DELETE /fonts/{font_name}` endpoint scoped to the current user's upload directory
- protect bundled fonts from deletion and avoid exposing whether another user owns a requested font
- add task-picker deletion controls only for user-uploaded fonts, including confirmation and selected-font fallback
- add focused backend, proxy-route, and UI tests

## Why

Self-hosted users currently have to remove custom font files manually from the backend volume. This adds an owner-safe deletion flow directly in the task UI while keeping bundled system fonts immutable.

## Validation

- `uv run pytest tests/unit/test_media_font_deletion.py --no-cov -q` — 4 passed
- `npm test` — 50 passed
- ESLint on touched frontend files — passed
- Python compilation on touched backend files — passed
- FastAPI route inspection confirmed both GET and DELETE registrations

## Existing baseline failures

- Full backend unit run: 103 passed, 1 unrelated existing assertion mismatch in `test_video_service.py` (`hook_title: None`)
- Repository-wide `tsc --noEmit`: two unrelated existing errors in `src/app/api/preferences/route.test.ts`

Closes #80