### PR TITLE
test(video): expect hook_title on fallback segment

### DIFF
--- a/backend/tests/unit/test_video_service.py
+++ b/backend/tests/unit/test_video_service.py
@@ -80,6 +80,7 @@ async def test_process_video_complete_uses_fallback_when_ai_selects_no_segments(
             "value_score": 0,
             "shareability_score": 0,
             "hook_type": "fallback",
+            "hook_title": None,
         }
     ]
     analysis = json.loads(result["analysis_json"])


### PR DESCRIPTION
## Summary

Main's CI has been red since #78: that PR added `hook_title` to rendered segments (`None` for the fallback window) but the expected dict in `test_process_video_complete_uses_fallback_when_ai_selects_no_segments` was never updated. This adds the missing key to the expectation.

## Validation

- `uv run pytest tests/unit/test_video_service.py --no-cov -q` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)