### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ ASSEMBLY_AI_HTTP_TIMEOUT_SECONDS=900
 # OpenAI (recommended: gpt-5.2)
 OPENAI_API_KEY=
 
+# Atlas Cloud (recommended: deepseek-ai/deepseek-v4-pro)
+ATLASCLOUD_API_KEY=
+
 # Google AI (recommended: gemini-3-flash)
 GOOGLE_API_KEY=
 
@@ -57,6 +60,7 @@ YOUTUBE_DATA_API_KEY=
 # Ollama can run locally without an API key.
 # Examples:
 #   - openai:gpt-5.2 (requires OPENAI_API_KEY) - latest, best reasoning
+#   - atlascloud:deepseek-ai/deepseek-v4-pro (requires ATLASCLOUD_API_KEY)
 #   - google-gla:gemini-3-flash-preview (requires GOOGLE_API_KEY) - fast, cost-effective
 #   - anthropic:claude-4-sonnet (requires ANTHROPIC_API_KEY)
 #   - ollama:gpt-oss:20b (uses local Ollama by default, optional OLLAMA_BASE_URL)

--- a/backend/src/ai.py
+++ b/backend/src/ai.py
@@ -11,10 +11,12 @@ import re
 from pydantic_ai import Agent
 from pydantic_ai.models import Model
 from pydantic_ai.models.ollama import OllamaModel
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.ollama import OllamaProvider
+from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic import AliasChoices, BaseModel, Field, field_validator
 
-from .config import Config, get_config
+from .config import ATLASCLOUD_BASE_URL, Config, get_config
 from .runtime_settings import apply_settings_to_process_env
 
 logger = logging.getLogger(__name__)
@@ -313,7 +315,14 @@ Find 2-5 compelling segments that would work well as standalone clips. Quality o
 _transcript_agent: Optional[Agent[None, TranscriptAnalysis]] = None
 _transcript_agent_signature: Optional[tuple[str | None, ...]] = None
 
-SUPPORTED_LLM_PROVIDERS = {"google", "google-gla", "openai", "anthropic", "ollama"}
+SUPPORTED_LLM_PROVIDERS = {
+    "google",
+    "google-gla",
+    "openai",
+    "atlascloud",
+    "anthropic",
+    "ollama",
+}
 
 
 def _split_llm_name(model_name: str) -> tuple[str, str | None]:
@@ -331,7 +340,7 @@ def _get_missing_llm_key_error(model_name: str, runtime_config: Config) -> Optio
     if provider not in SUPPORTED_LLM_PROVIDERS:
         return (
             f"Unsupported LLM provider '{provider}'. "
-            "Use google-gla:*, openai:*, anthropic:*, or ollama:*."
+            "Use google-gla:*, openai:*, atlascloud:*, anthropic:*, or ollama:*."
         )
 
     if not provider_model_name:
@@ -352,6 +361,12 @@ def _get_missing_llm_key_error(model_name: str, runtime_config: Config) -> Optio
             "Set OPENAI_API_KEY or choose another provider with a matching API key."
         )
 
+    if provider == "atlascloud" and not runtime_config.atlascloud_api_key:
+        return (
+            "Selected LLM provider is Atlas Cloud, but ATLASCLOUD_API_KEY is not set. "
+            "Set ATLASCLOUD_API_KEY or choose another provider with a matching API key."
+        )
+
     if provider == "anthropic" and not runtime_config.anthropic_api_key:
         return (
             "Selected LLM provider is Anthropic, but ANTHROPIC_API_KEY is not set. "
@@ -368,6 +383,20 @@ def _get_missing_llm_key_error(model_name: str, runtime_config: Config) -> Optio
 
 def _build_transcript_model(runtime_config: Config) -> Model | str:
     provider, provider_model_name = _split_llm_name(runtime_config.llm)
+    if provider == "atlascloud":
+        if not provider_model_name:
+            raise RuntimeError(
+                "Selected LLM provider is Atlas Cloud, but no model name was provided. "
+                "Use the format atlascloud:<model>."
+            )
+        return OpenAIChatModel(
+            provider_model_name,
+            provider=OpenAIProvider(
+                base_url=ATLASCLOUD_BASE_URL,
+                api_key=runtime_config.atlascloud_api_key,
+            ),
+        )
+
     if provider != "ollama":
         return runtime_config.llm
 
@@ -394,6 +423,7 @@ def get_transcript_agent() -> Agent[None, TranscriptAnalysis]:
     signature = (
         runtime_config.llm,
         runtime_config.openai_api_key,
+        runtime_config.atlascloud_api_key,
         runtime_config.google_api_key,
         runtime_config.anthropic_api_key,
         runtime_config.ollama_base_url,

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -37,6 +37,11 @@ SETTING_METADATA = {
         "description": "Required for openai:* models.",
         "input_type": "password",
     },
+    "ATLASCLOUD_API_KEY": {
+        "label": "Atlas Cloud API key",
+        "description": "Required for atlascloud:* models.",
+        "input_type": "password",
+    },
     "GOOGLE_API_KEY": {
         "label": "Google API key",
         "description": "Required for google-gla:* models and fallback YouTube metadata.",

--- a/backend/src/config.py
+++ b/backend/src/config.py
@@ -8,11 +8,13 @@ load_dotenv()
 _config_override = None
 LOCAL_OLLAMA_BASE_URL = "http://localhost:11434/v1"
 DOCKER_OLLAMA_BASE_URL = "http://host.docker.internal:11434/v1"
+ATLASCLOUD_BASE_URL = "https://api.atlascloud.ai/v1"
 
 
 class Config:
     def __init__(self):
         self.openai_api_key = self._get_runtime_setting("OPENAI_API_KEY")
+        self.atlascloud_api_key = self._get_runtime_setting("ATLASCLOUD_API_KEY")
         self.anthropic_api_key = self._get_runtime_setting("ANTHROPIC_API_KEY")
         self.google_api_key = self._get_runtime_setting("GOOGLE_API_KEY")
         self.youtube_data_api_key = self._get_runtime_setting("YOUTUBE_DATA_API_KEY")
@@ -124,6 +126,7 @@ class Config:
             "ASSEMBLY_AI_API_KEY": self.assembly_ai_api_key,
             "LLM": self.llm,
             "OPENAI_API_KEY": self.openai_api_key,
+            "ATLASCLOUD_API_KEY": self.atlascloud_api_key,
             "GOOGLE_API_KEY": self.google_api_key,
             "ANTHROPIC_API_KEY": self.anthropic_api_key,
             "OLLAMA_BASE_URL": self.ollama_base_url,
@@ -196,6 +199,8 @@ class Config:
             return "openai:gpt-5.2"
         if self.anthropic_api_key:
             return "anthropic:claude-4-sonnet"
+        if self.atlascloud_api_key:
+            return "atlascloud:deepseek-ai/deepseek-v4-pro"
         return "google-gla:gemini-3-flash-preview"
 
 

--- a/backend/src/runtime_settings.py
+++ b/backend/src/runtime_settings.py
@@ -16,6 +16,7 @@ RUNTIME_SETTING_KEYS: tuple[str, ...] = (
     "ASSEMBLY_AI_API_KEY",
     "LLM",
     "OPENAI_API_KEY",
+    "ATLASCLOUD_API_KEY",
     "GOOGLE_API_KEY",
     "ANTHROPIC_API_KEY",
     "OLLAMA_BASE_URL",
@@ -28,6 +29,7 @@ RUNTIME_SETTING_KEYS: tuple[str, ...] = (
 PROCESS_ENV_SETTING_KEYS = frozenset(
     {
         "OPENAI_API_KEY",
+        "ATLASCLOUD_API_KEY",
         "GOOGLE_API_KEY",
         "ANTHROPIC_API_KEY",
         "OLLAMA_BASE_URL",

--- a/backend/tests/unit/test_ai_prompt.py
+++ b/backend/tests/unit/test_ai_prompt.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from pydantic_ai.models.ollama import OllamaModel
+from pydantic_ai.models.openai import OpenAIChatModel
 
 from src.ai import (
     IDEAL_CLIP_MAX_SECONDS,
@@ -17,6 +18,7 @@ from src.ai import (
     build_transcript_analysis_prompt,
     transcript_analysis_system_prompt,
 )
+from src.config import Config
 
 
 def test_system_prompt_enforces_grounding_rules():
@@ -85,6 +87,33 @@ def test_ollama_llm_builds_native_ollama_model():
     assert model.base_url == "http://ollama.example/v1/"
 
 
+def test_atlascloud_llm_builds_openai_compatible_model():
+    runtime_config = SimpleNamespace(
+        llm="atlascloud:deepseek-ai/deepseek-v4-pro",
+        atlascloud_api_key="test-atlas-key",
+    )
+
+    model = _build_transcript_model(runtime_config)
+
+    assert isinstance(model, OpenAIChatModel)
+    assert model.model_name == "deepseek-ai/deepseek-v4-pro"
+    assert model.provider.base_url == "https://api.atlascloud.ai/v1/"
+
+
+def test_atlascloud_key_infers_default_when_other_provider_keys_are_missing():
+    runtime_config = SimpleNamespace(
+        google_api_key=None,
+        openai_api_key=None,
+        anthropic_api_key=None,
+        atlascloud_api_key="test-atlas-key",
+    )
+
+    assert (
+        Config._infer_default_llm(runtime_config)
+        == "atlascloud:deepseek-ai/deepseek-v4-pro"
+    )
+
+
 def test_parse_transcript_timestamp_supports_minute_and_hour_formats():
     assert _parse_transcript_timestamp_seconds("02:35") == 155
     assert _parse_transcript_timestamp_seconds("01:02:35") == 3755
@@ -125,6 +154,7 @@ def test_llm_validation_rejects_unsupported_or_incomplete_model_names():
     runtime_config = SimpleNamespace(
         google_api_key=None,
         openai_api_key=None,
+        atlascloud_api_key=None,
         anthropic_api_key=None,
     )
 
@@ -135,3 +165,6 @@ def test_llm_validation_rejects_unsupported_or_incomplete_model_names():
         "ollama:", runtime_config
     )
     assert _get_missing_llm_key_error("ollama:gpt-oss:20b", runtime_config) is None
+    assert "ATLASCLOUD_API_KEY" in _get_missing_llm_key_error(
+        "atlascloud:deepseek-ai/deepseek-v4-pro", runtime_config
+    )


### PR DESCRIPTION
## What changed

- add `atlascloud:<model>` as a first-class transcript-analysis provider
- route it through Pydantic AI's OpenAI-compatible client at `https://api.atlascloud.ai/v1`
- expose `ATLASCLOUD_API_KEY` through the existing encrypted runtime-settings flow
- use `deepseek-ai/deepseek-v4-pro` when Atlas Cloud is the only configured provider

## Validation

- `14 passed` across focused AI/config tests
- Ruff critical checks and Python `compileall` passed
- Atlas model catalog returned HTTP 200 and contains the default model
- live Atlas chat completion returned HTTP 200
- `git diff --check` and secret scan passed

No README, docs, logo, sponsor, credits, or partner-promotion content was added.