### PR TITLE
fix(backend): release database sessions before streaming

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "apify-client>=1.8.1",
-    "fastapi>=0.110.0",
+    "fastapi>=0.121.0",
     "uvicorn>=0.27.0",
     "openai-whisper>=20250625",
     "pydantic-ai>=1.89.1",

--- a/backend/src/api/routes/media.py
+++ b/backend/src/api/routes/media.py
@@ -87,7 +87,9 @@ async def get_available_fonts_route(
 
 @router.get("/fonts/{font_name}")
 async def get_font_file(
-    font_name: str, request: Request, db: AsyncSession = Depends(get_db)
+    font_name: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db, scope="function"),
 ):
     """Serve a specific font file."""
     try:

--- a/backend/src/api/routes/tasks.py
+++ b/backend/src/api/routes/tasks.py
@@ -366,7 +366,9 @@ async def get_shared_task(share_token: str, db: AsyncSession = Depends(get_db)):
 
 @router.get("/shared/{share_token}/clips/{clip_id}/file")
 async def get_shared_clip_file(
-    share_token: str, clip_id: str, db: AsyncSession = Depends(get_db)
+    share_token: str,
+    clip_id: str,
+    db: AsyncSession = Depends(get_db, scope="function"),
 ):
     """Serve one shared clip only when the bearer share token is enabled."""
     task_service = TaskService(db)
@@ -635,7 +637,10 @@ async def delete_clip(
 
 @router.get("/{task_id}/clips/{clip_id}/file")
 async def get_clip_file(
-    task_id: str, clip_id: str, request: Request, db: AsyncSession = Depends(get_db)
+    task_id: str,
+    clip_id: str,
+    request: Request,
+    db: AsyncSession = Depends(get_db, scope="function"),
 ):
     """Serve a clip file after verifying task ownership."""
     try:
@@ -879,7 +884,7 @@ async def export_clip(
     clip_id: str,
     request: Request,
     preset: str = "tiktok",
-    db: AsyncSession = Depends(get_db),
+    db: AsyncSession = Depends(get_db, scope="function"),
 ):
     """Export clip with a social platform preset."""
     try:

--- a/backend/src/main_refactored.py
+++ b/backend/src/main_refactored.py
@@ -202,11 +202,11 @@ def create_app(
             await db.execute(text("SELECT 1"))
             return {"status": "healthy", "database": "connected"}
         except Exception as e:
-            return {
-                "status": "unhealthy",
-                "database": "disconnected",
-                "error": str(e),
-            }
+            logger.error("Database health check failed: %s", e)
+            return JSONResponse(
+                status_code=503,
+                content={"status": "unhealthy", "database": "disconnected"},
+            )
 
     @app.get("/health/redis")
     async def check_redis_health():

--- a/backend/tests/integration/test_health_and_tasks.py
+++ b/backend/tests/integration/test_health_and_tasks.py
@@ -1,7 +1,9 @@
 import pytest
 
+from fastapi.routing import APIRoute
 from sqlalchemy import text
 
+from src.database import get_db
 from tests.fixtures.factories import create_clip, create_source, create_task, create_user
 
 
@@ -18,6 +20,54 @@ async def test_health_endpoints_report_healthy(client):
     redis_response = await client.get("/health/redis")
     assert redis_response.status_code == 200
     assert redis_response.json()["status"] == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_database_health_returns_503_when_the_database_is_unavailable(
+    app, client
+):
+    class UnavailableDatabaseSession:
+        async def execute(self, _statement):
+            raise RuntimeError("database unavailable")
+
+    async def unavailable_database():
+        yield UnavailableDatabaseSession()
+
+    app.dependency_overrides[get_db] = unavailable_database
+    try:
+        response = await client.get("/health/db")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 503
+    assert response.json() == {
+        "status": "unhealthy",
+        "database": "disconnected",
+    }
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/tasks/shared/{share_token}/clips/{clip_id}/file",
+        "/tasks/{task_id}/clips/{clip_id}/file",
+        "/tasks/{task_id}/clips/{clip_id}/export",
+        "/fonts/{font_name}",
+    ],
+)
+def test_database_backed_file_routes_release_sessions_before_streaming(app, path):
+    route = next(
+        route
+        for route in app.routes
+        if isinstance(route, APIRoute) and route.path == path
+    )
+    database_dependency = next(
+        dependency
+        for dependency in route.dependant.dependencies
+        if dependency.call is get_db
+    )
+
+    assert database_dependency.scope == "function"
 
 
 @pytest.mark.asyncio

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -4382,7 +4382,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "cryptography", specifier = ">=42.0.0" },
-    { name = "fastapi", specifier = ">=0.110.0" },
+    { name = "fastapi", specifier = ">=0.121.0" },
     { name = "greenlet", specifier = ">=2.0.0" },
     { name = "mediapipe", specifier = ">=0.10.0" },
     { name = "numpy", specifier = ">=1.24.0" },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,7 +139,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health/db"]
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary

- release database dependencies before database-backed file responses begin streaming
- return HTTP 503 when the database health check fails
- use the database health endpoint for the backend container healthcheck
- require a FastAPI version that supports function-scoped yield dependencies

## Testing

- backend test suite
- Python compile check
- Docker Compose configuration validation
- diff whitespace validation